### PR TITLE
Convenience `assert.ok()` aliases: `should.exist()` and `should.not.exist()`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -244,6 +244,8 @@ Yes, yes it does, with a single getter _should_, and no it wont break your code,
 
 Copyright (c) 2010 TJ Holowaychuk &lt;tj@vision-media.ca&gt;
 
+Copyright (c) 2011 Aseem Kishore &lt;aseem.kishore@gmail.com&gt;
+
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 'Software'), to deal in the Software without restriction, including

--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,22 @@ _should_ literally extends node's _assert_ module, in fact, it is node's assert 
 
     $ npm install should
 
+## assert extras
+
+As mentioned above, _should_ extends node's _assert_. The returned object from `require('should')` is thus similar to the returned object from `require('assert')`, but it has one extra convenience method:
+
+    should.exist('hello')
+    should.exist([])
+    should.exist(null)  // will throw
+
+This is equivalent to `should.ok`, which is equivalent to `assert.ok`, but reads a bit better. It gets better, though:
+
+    should.not.exist(false)
+    should.not.exist('')
+    should.not.exist({})    // will throw
+
+We may add more _assert_ extras in the future... ;)
+
 ## modifiers
 
  _should_'s assertion chaining provides an expressive way to build up an assertion, along with dummy getters such as _an_, _have_, and _be_, provided are what I am simply calling **modifiers**, which have a meaning effect on the assertion. An example of this is the _not_ getter, which negates the meaning, aka `user.should.not.have.property('name')`. In the previous example note the use of _have_, as we could omit it and still construct a valid assertion.

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,6 @@
-  _should_ is an expressive, test framework agnostic, assertion library for [node](http://nodejs.org). 
+_should_ is an expressive, readable, test framework agnostic, assertion library for [node](http://nodejs.org).
+  
+It extends the Object prototype with a single non-enumerable getter that allows you to express how that object should behave.
 
 _should_ literally extends node's _assert_ module, in fact, it is node's assert module, for example `should.equal(str, 'foo')` will work, just as `assert.equal(str, 'foo')` would, and `should.AssertionError` **is** `asset.AssertionError`, meaning any test framework supporting this constructor will function properly with _should_.
 
@@ -11,26 +13,16 @@ _should_ literally extends node's _assert_ module, in fact, it is node's assert 
 
     user.should.have.property('name', 'tj');
     user.should.have.property('pets').with.lengthOf(4)
+    
+    someAsyncTask(foo, function (err, result) {
+        should.not.exist(err);
+        should.exist(result);
+        result.bar.should.equal(foo);
+    });
 
 ## Installation
 
     $ npm install should
-
-## assert extras
-
-As mentioned above, _should_ extends node's _assert_. The returned object from `require('should')` is thus similar to the returned object from `require('assert')`, but it has one extra convenience method:
-
-    should.exist('hello')
-    should.exist([])
-    should.exist(null)  // will throw
-
-This is equivalent to `should.ok`, which is equivalent to `assert.ok`, but reads a bit better. It gets better, though:
-
-    should.not.exist(false)
-    should.not.exist('')
-    should.not.exist({})    // will throw
-
-We may add more _assert_ extras in the future... ;)
 
 ## modifiers
 
@@ -51,6 +43,39 @@ which is essentially equivalent to below, however the property may not exist:
 our dummy getters such as _and_ also help express chaining:
 
     user.should.be.a('object').and.have.property('name', 'tj')
+
+## exist (static)
+
+The returned object from `require('should')` is the same object as `require('assert')`. So you can use `should` just like `assert`:
+
+    should.fail('expected an error!')
+    should.strictEqual(foo, bar)
+
+In general, using the Object prototype's _should_ is nicer than using these `assert` equivalents, because _should_ gives you access to the expressive and readable language described above:
+
+    foo.should.equal(bar)   // same as should.strictEqual(foo, bar) above
+
+The only exception, though, is when you can't be sure that a particular object exists. In that case, attempting to access the _should_ property may throw a TypeError:
+
+    foo.should.equal(bar)   // throws if foo is null or undefined!
+
+For this case, `require('should')` extends `require('assert')` with an extra convenience method to check whether an object exists:
+
+    should.exist({})
+    should.exist([])
+    should.exist('')
+    should.exist(0)
+    should.exist(null)      // will throw
+    should.exist(undefined) // will throw
+
+You can also check the negation:
+
+    should.not.exist(undefined)
+    should.not.exist(null)
+    should.not.exist('')    // will throw
+    should.not.exist({})    // will throw
+
+Once you know an object exists, you can safely use the _should_ property on it.
 
 ## ok
 

--- a/lib/should.js
+++ b/lib/should.js
@@ -13,8 +13,7 @@ var util = require('sys')
   , assert = require('assert')
   , AssertionError = assert.AssertionError
   , eql = require('./eql')
-  , i = util.inspect
-  , should;
+  , i = util.inspect;
 
 /**
  * Expose assert as should.
@@ -26,13 +25,13 @@ var util = require('sys')
  *
  */
 
-should = exports = module.exports = assert;
+exports = module.exports = assert;
 
 /**
  * Library version.
  */
 
-should.version = '0.0.4';
+exports.version = '0.0.4';
 
 /**
  * Assert _obj_ exists, with optional message.
@@ -42,7 +41,7 @@ should.version = '0.0.4';
  * @api public
  */
  
-should.exist = function(obj, msg){
+exports.exist = function(obj, msg){
   if (obj == null) {    // covers undefined also
     throw new AssertionError({
         message: msg || ('expected ' + i(obj) + ' to exist')
@@ -61,8 +60,8 @@ should.exist = function(obj, msg){
 
 // TEMP simple implementation for now instead of keeping track of negation.
 // we may want to do this properly down the line to support other verbs.
-should.not = {};
-should.not.exist = function(obj, msg){
+exports.not = {};
+exports.not.exist = function(obj, msg){
   if (obj != null) {    // covers undefined also
     throw new AssertionError({
         message: msg || ('expected ' + i(obj) + ' to not exist')

--- a/lib/should.js
+++ b/lib/should.js
@@ -13,7 +13,8 @@ var util = require('sys')
   , assert = require('assert')
   , AssertionError = assert.AssertionError
   , eql = require('./eql')
-  , i = util.inspect;
+  , i = util.inspect
+  , should;
 
 /**
  * Expose assert as should.
@@ -25,13 +26,52 @@ var util = require('sys')
  *
  */
 
-exports = module.exports = assert;
+should = exports = module.exports = assert;
 
 /**
  * Library version.
  */
 
-exports.version = '0.0.4';
+should.version = '0.0.4';
+
+/**
+ * Assert _obj_ exists, with optional message.
+ * (Equivalent to `should#ok`.)
+ *
+ * @param {Mixed} obj
+ * @param {String} msg
+ * @api public
+ */
+ 
+should.exist = function(obj, msg){
+  if (!obj) {
+    throw new AssertionError({
+        message: msg || ('expected ' + i(obj) + ' to exist')
+      , stackStartFunction: should.exist
+    });
+  }
+};
+
+/**
+ * Asserts _obj_ does not exist, with optional message.
+ * (Equivalent to `should#ok(!obj)`.)
+ *
+ * @param {Mixed} obj
+ * @param {String} msg
+ * @api public
+ */
+
+// TEMP simple implementation for now instead of keeping track of negation.
+// we may want to do this properly down the line to support other verbs.
+should.not = {};
+should.not.exist = function(obj, msg){
+  if (obj) {
+    throw new AssertionError({
+        message: msg || ('expected ' + i(obj) + ' to not exist')
+      , stackStartFunction: should.not.exist
+    });
+  }
+};
 
 /**
  * Expose api via `Object#should`.

--- a/lib/should.js
+++ b/lib/should.js
@@ -36,7 +36,6 @@ should.version = '0.0.4';
 
 /**
  * Assert _obj_ exists, with optional message.
- * (Equivalent to `should#ok`.)
  *
  * @param {Mixed} obj
  * @param {String} msg
@@ -44,7 +43,7 @@ should.version = '0.0.4';
  */
  
 should.exist = function(obj, msg){
-  if (!obj) {
+  if (obj == null) {    // covers undefined also
     throw new AssertionError({
         message: msg || ('expected ' + i(obj) + ' to exist')
       , stackStartFunction: should.exist
@@ -54,7 +53,6 @@ should.exist = function(obj, msg){
 
 /**
  * Asserts _obj_ does not exist, with optional message.
- * (Equivalent to `should#ok(!obj)`.)
  *
  * @param {Mixed} obj
  * @param {String} msg
@@ -65,7 +63,7 @@ should.exist = function(obj, msg){
 // we may want to do this properly down the line to support other verbs.
 should.not = {};
 should.not.exist = function(obj, msg){
-  if (obj) {
+  if (obj != null) {    // covers undefined also
     throw new AssertionError({
         message: msg || ('expected ' + i(obj) + ' to not exist')
       , stackStartFunction: should.not.exist

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   , "description": "test framework agnostic BDD-style assertions"
   , "version": "0.0.4"
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
+  , "contributors": [ "Aseem Kishore <aseem.kishore@gmail.com>" ]
   , "keywords": ["test", "bdd", "assert"]
   , "main": "./lib/should.js"
   , "engines": { "node": ">= 0.2.0" }

--- a/test/exist.test.js
+++ b/test/exist.test.js
@@ -31,16 +31,16 @@ module.exports = {
   
   // static should.exist() pass:
   
-  'test static should.exist() pass w/ true': function () {
-    should.exist(true);
+  'test static should.exist() pass w/ bool': function () {
+    should.exist(false);
   },
   
   'test static should.exist() pass w/ number': function () {
-    should.exist(42);
+    should.exist(0);
   },
   
   'test static should.exist() pass w/ string': function () {
-    should.exist('hello');
+    should.exist('');
   },
   
   'test static should.exist() pass w/ object': function () {
@@ -53,18 +53,6 @@ module.exports = {
   
   // static should.exist() fail:
   
-  'test static should.exist() fail w/ false': function () {
-    err_should_exist(false)
-  },
-  
-  'test static should.exist() fail w/ zero': function () {
-    err_should_exist(0)
-  },
-  
-  'test static should.exist() fail w/ empty string': function () {
-    err_should_exist('')
-  },
-  
   'test static should.exist() fail w/ null': function () {
     err_should_exist(null)
   },
@@ -74,18 +62,6 @@ module.exports = {
   },
   
   // static should.not.exist() pass:
-  
-  'test static should.not.exist() pass w/ false': function () {
-    should.not.exist(false);
-  },
-  
-  'test static should.not.exist() pass w/ zero': function () {
-    should.not.exist(0);
-  },
-  
-  'test static should.not.exist() pass w/ empty string': function () {
-    should.not.exist('');
-  },
   
   'test static should.not.exist() pass w/ null': function () {
     should.not.exist(null);
@@ -97,16 +73,16 @@ module.exports = {
   
   // static should.not.exist() fail:
   
-  'test static should.not.exist() fail w/ true': function () {
-    err_should_not_exist(true)
+  'test static should.not.exist() fail w/ bool': function () {
+    err_should_not_exist(false)
   },
   
   'test static should.not.exist() fail w/ number': function () {
-    err_should_not_exist(42)
+    err_should_not_exist(0)
   },
   
   'test static should.not.exist() fail w/ string': function () {
-    err_should_not_exist('hello')
+    err_should_not_exist('')
   },
   
   'test static should.not.exist() fail w/ object': function () {

--- a/test/exist.test.js
+++ b/test/exist.test.js
@@ -1,0 +1,124 @@
+
+/**
+ * Module dependencies.
+ */
+
+var should = require('should');
+var util = require('util');
+
+function err(fn, msg) {
+  try {
+    fn();
+    should.fail('expected an error');
+  } catch (err) {
+    should.equal(msg, err.message);
+  }
+}
+
+function err_should_exist(obj) {
+  err(function () {
+    should.exist(obj);
+  }, 'expected ' + util.inspect(obj) + ' to exist');
+}
+
+function err_should_not_exist(obj) {
+  err(function () {
+    should.not.exist(obj);
+  }, 'expected ' + util.inspect(obj) + ' to not exist');
+}
+
+module.exports = {
+  
+  // static should.exist() pass:
+  
+  'test static should.exist() pass w/ true': function () {
+    should.exist(true);
+  },
+  
+  'test static should.exist() pass w/ number': function () {
+    should.exist(42);
+  },
+  
+  'test static should.exist() pass w/ string': function () {
+    should.exist('hello');
+  },
+  
+  'test static should.exist() pass w/ object': function () {
+    should.exist({});
+  },
+  
+  'test static should.exist() pass w/ array': function () {
+    should.exist([]);
+  },
+  
+  // static should.exist() fail:
+  
+  'test static should.exist() fail w/ false': function () {
+    err_should_exist(false)
+  },
+  
+  'test static should.exist() fail w/ zero': function () {
+    err_should_exist(0)
+  },
+  
+  'test static should.exist() fail w/ empty string': function () {
+    err_should_exist('')
+  },
+  
+  'test static should.exist() fail w/ null': function () {
+    err_should_exist(null)
+  },
+  
+  'test static should.exist() fail w/ undefined': function () {
+    err_should_exist(undefined)
+  },
+  
+  // static should.not.exist() pass:
+  
+  'test static should.not.exist() pass w/ false': function () {
+    should.not.exist(false);
+  },
+  
+  'test static should.not.exist() pass w/ zero': function () {
+    should.not.exist(0);
+  },
+  
+  'test static should.not.exist() pass w/ empty string': function () {
+    should.not.exist('');
+  },
+  
+  'test static should.not.exist() pass w/ null': function () {
+    should.not.exist(null);
+  },
+  
+  'test static should.not.exist() pass w/ undefined': function () {
+    should.not.exist(undefined);
+  },
+  
+  // static should.not.exist() fail:
+  
+  'test static should.not.exist() fail w/ true': function () {
+    err_should_not_exist(true)
+  },
+  
+  'test static should.not.exist() fail w/ number': function () {
+    err_should_not_exist(42)
+  },
+  
+  'test static should.not.exist() fail w/ string': function () {
+    err_should_not_exist('hello')
+  },
+  
+  'test static should.not.exist() fail w/ object': function () {
+    err_should_not_exist({})
+  },
+  
+  'test static should.not.exist() fail w/ array': function () {
+    err_should_not_exist([])
+  },
+  
+  // TODO instance tests (e.g. `true.should.exist()`) if we implement them.
+  // not sure if instance is worth implementing; `foo.should.exist()` will often
+  // just not work if `foo` is null or undefined. thus only static for now.
+  
+};

--- a/test/exist.test.js
+++ b/test/exist.test.js
@@ -54,11 +54,11 @@ module.exports = {
   // static should.exist() fail:
   
   'test static should.exist() fail w/ null': function () {
-    err_should_exist(null)
+    err_should_exist(null);
   },
   
   'test static should.exist() fail w/ undefined': function () {
-    err_should_exist(undefined)
+    err_should_exist(undefined);
   },
   
   // static should.not.exist() pass:
@@ -74,27 +74,23 @@ module.exports = {
   // static should.not.exist() fail:
   
   'test static should.not.exist() fail w/ bool': function () {
-    err_should_not_exist(false)
+    err_should_not_exist(false);
   },
   
   'test static should.not.exist() fail w/ number': function () {
-    err_should_not_exist(0)
+    err_should_not_exist(0);
   },
   
   'test static should.not.exist() fail w/ string': function () {
-    err_should_not_exist('')
+    err_should_not_exist('');
   },
   
   'test static should.not.exist() fail w/ object': function () {
-    err_should_not_exist({})
+    err_should_not_exist({});
   },
   
   'test static should.not.exist() fail w/ array': function () {
-    err_should_not_exist([])
+    err_should_not_exist([]);
   },
-  
-  // TODO instance tests (e.g. `true.should.exist()`) if we implement them.
-  // not sure if instance is worth implementing; `foo.should.exist()` will often
-  // just not work if `foo` is null or undefined. thus only static for now.
   
 };


### PR DESCRIPTION
For handling the null/undefined case, I implemented `should.exist()` as an alias for `assert.ok()`, which is itself more readable than `should.ok()`. (Technically, it's not an exact alias; it has a better failure message.) I also implemented the inverse: `should.not.exist()`.

The result:

```
someAsyncFunction(foo, bar, function (err, result) {
    should.not.exist(err);
    should.exist(result);
    result.should.have.property('baz');
    // ...
});
```

I love the improved readability. Hope you like it too. =)

Cheers,
Aseem
