### PR TITLE
Enabling `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,4 +6,7 @@
   , "keywords": ["test", "bdd", "assert"]
   , "main": "./lib/should.js"
   , "engines": { "node": ">= 0.2.0" }
+  , "scripts" : {
+    "test": "expresso"
+  }
 }


### PR DESCRIPTION
package.json lacks script/test to run tests before install. Added it.
