### PR TITLE
Assertion for inclusion of an object

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -211,6 +211,15 @@ Substring assertion:
     'foobar'.should.include.string('bar')
     'foobar'.should.not.include.string('baz')
 
+## object
+
+Assert inclusion of object:
+
+    var obj = {foo: 'bar', baz: {baaz: 42}};
+    obj.should.include.object({foo: 'bar'});
+    obj.should.include.object({baz: {baaz: 42}});
+    obj.should.not.include.object({foo: 'baz'});
+
 ## property
 
 Assert property exists and has optional value:

--- a/lib/should.js
+++ b/lib/should.js
@@ -435,6 +435,29 @@ Assertion.prototype = {
   },
 
   /**
+   * Assert inclusion of object.
+   *
+   * @param {Object} obj
+   * @api public
+   */
+
+  object: function(obj){
+    this.obj.should.be.a('object');
+    var included = true;
+    for (var key in obj) {
+      if (obj.hasOwnProperty(key) && !eql(obj[key], this.obj[key])) {
+        included = false;
+        break;
+      }
+    }
+    this.assert(
+        included
+      , 'expected ' + this.inspect + ' to include ' + i(obj)
+      , 'expected ' + this.inspect + ' to not include ' + i(obj));
+    return this;
+  },
+
+  /**
    * Assert property _name_ exists, with optional _val_.
    *
    * @param {String} name
@@ -619,3 +642,4 @@ Assertion.prototype = {
 ('ownProperty', 'haveOwnProperty')
 ('above', 'greaterThan')
 ('below', 'lessThan');
+

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -253,7 +253,29 @@ module.exports = {
       'foobar'.should.not.include.string('bar');
     }, "expected 'foobar' to not include 'bar'");
   },
-  
+
+  'test object()': function(){
+    var obj = {foo: 'bar', baz: {baaz: 42}, qux: 13};
+    obj.should.include.object({foo: 'bar'});
+    obj.should.include.object({baz: {baaz: 42}});
+    obj.should.include.object({foo: 'bar', qux: 13});
+    obj.should.not.include.object({foo: 'baz'});
+    obj.should.not.include.object({foo: 'bar', baz: {baaz: -42}});
+
+    err(function(){
+      (3).should.include.object({foo: 'bar'});
+    }, "expected 3 to be a object");
+
+    err(function(){
+      var obj = {foo: 'bar'};
+      obj.should.include.object({foo: 'baz'});
+    }, "expected { foo: 'bar' } to include { foo: 'baz' }");
+
+    err(function(){
+      var obj = {foo: 'bar'};
+      obj.should.not.include.object({foo: 'bar'});
+    }, "expected { foo: 'bar' } to not include { foo: 'bar' }");
+  },
   'test contain()': function(){
     ['foo', 'bar'].should.contain('foo');
     ['foo', 'bar'].should.contain('foo');


### PR DESCRIPTION
`obj.should.include.object({ foo: 'bar' })` implementation along with tests and readme update.

I use this all over my code when I don't know all the properties of an object I want to test against.
