### PR TITLE
Do not attach `should` to my prototype permanently, thank you.

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -1,4 +1,3 @@
-
 /*!
  * Should
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -80,7 +79,8 @@ Object.defineProperty(Object.prototype, 'should', {
   set: function(){},
   get: function(){
     return new Assertion(this);
-  }
+  },
+  configurable: true
 });
 
 /**


### PR DESCRIPTION
Simply by setting the `configurable` flag to `true` I can undo your corruption of my `Object.prototype`

Use-case: [vows-is](https://github.com/Raynos/vows-is) re-uses your lovely should code but only [attaches `should` to my `it` object](https://github.com/Raynos/vows-is/blob/master/vows-is.js#L105).

[Demonstration of me not being able to remove `should` from the prototype](http://jsfiddle.net/gmnHp/21/)
