### PR TITLE
Check if an Array includes an object equal to a specified object.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -255,6 +255,14 @@ Assert substring:
     'foo bar baz'.should.include('baz')
     'foo bar baz'.should.not.include('FOO')
 
+## includeEql(obj)
+
+    Assert that an object equal to the given `obj` is present in an Array:
+
+    [[1],[2],[3]].should.includeEql([3])
+    [[1],[2],[3]].should.includeEql([2])
+    [[1],[2],[3]].should.not.includeEql([4])
+
 ## throw()
 
   Assert exceptions:

--- a/lib/should.js
+++ b/lib/should.js
@@ -469,6 +469,21 @@ Assertion.prototype = {
 
     return this;
   },
+  
+  /**
+   * Assert that an object equal to `obj` is present.
+   *
+   * @param {Array} obj
+   * @api public
+   */
+
+  includeEql: function(obj){
+    this.assert(
+      this.obj.some(function(item) { return eql(obj, item); })
+      , 'expected ' + this.inspect + ' to include an object equal to ' + i(obj)
+      , 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj));
+    return this;
+  },
 
   /**
    * Assert that the array contains _obj_.

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -267,6 +267,21 @@ module.exports = {
     }, "expected [ 'bar', 'foo' ] to not include 'foo'");
   },
   
+  'test includeEql() with array': function(){
+    [['foo'], ['bar']].should.includeEql(['foo']);
+    [['foo'], ['bar']].should.includeEql(['bar']);
+    [['foo'], ['bar']].should.not.includeEql(['baz']);
+    [].should.not.includeEql(['baz']);
+    
+    err(function(){
+      [['foo']].should.includeEql(['bar']);
+    }, "expected [ [ 'foo' ] ] to include an object equal to [ 'bar' ]");
+    
+    err(function(){
+      [['foo']].should.not.includeEql(['foo']);
+    }, "expected [ [ 'foo' ] ] to not include an object equal to [ 'foo' ]");
+  },
+  
   'test keys(array)': function(){
     ({ foo: 1 }).should.have.keys(['foo']);
     ({ foo: 1, bar: 2 }).should.have.keys(['foo', 'bar']);


### PR DESCRIPTION
Since `include` uses `indexOf`, it cannot test for equality.

I have added an `includeEql` method that tests whether an object equal to the specified one is present in the array.

One prominent case occurs when testing an array of arrays:

```
[[1],[2],[3]].should.not.include([3])
[[1],[2],[3]].should.not.include([2])
[[1],[2],[3]].should.not.include([4])
```

But, thanks to this extension:

```
[[1],[2],[3]].should.includeEql([3])
[[1],[2],[3]].should.includeEql([2])
[[1],[2],[3]].should.not.includeEql([4])
```
