### PR TITLE
Added optional failure description to several matchers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -288,6 +288,18 @@ and will fail if you omit a key or two:
     obj.should.have.keys('foo', 'bar');
     obj.should.have.keys(['foo', 'bar']);
 
+## Optional Error description
+
+As it can often be difficult to assertain exactly where failed assertions are comming from in your tests, an optional description parameter can be passed to several should matchers. The description will follow the failed assertion in the error:
+
+    (1).should.eql(0, 'some useful description')
+
+    AssertionError: expected 1 to equal 0 | some useful description
+      at Object.eql (/Users/swift/code/should.js/node_modules/should/lib/should.js:280:10)
+      ...
+
+The methods that support this optional description are: `eql`, `equal`, `within`, `a`, `instanceof`, `above`, `below`, `match`, `length`, `property`, `ownProperty`, `include`, `includeEql`, and `throw`.
+
 ## Express example
 
 For example you can use should with the [Expresso TDD Framework](http://github.com/visionmedia/expresso) by simply including it:

--- a/lib/should.js
+++ b/lib/should.js
@@ -280,8 +280,8 @@ Assertion.prototype = {
   eql: function(val, desc){
     this.assert(
         eql(val, this.obj)
-      , 'expected ' + this.inspect + ' to equal ' + i(val) + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' to not equal ' + i(val) + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to equal ' + i(val) + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not equal ' + i(val) + (desc ? " | " + desc : ""));
     return this;
   },
   
@@ -296,8 +296,8 @@ Assertion.prototype = {
   equal: function(val, desc){
     this.assert(
         val === this.obj
-      , 'expected ' + this.inspect + ' to equal ' + i(val) + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' to not equal ' + i(val) + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to equal ' + i(val) + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not equal ' + i(val) + (desc ? " | " + desc : ""));
     return this;
   },
   
@@ -314,8 +314,8 @@ Assertion.prototype = {
     var range = start + '..' + finish;
     this.assert(
         this.obj >= start && this.obj <= finish
-      , 'expected ' + this.inspect + ' to be within ' + range + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' to not be within ' + range + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to be within ' + range + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not be within ' + range + (desc ? " | " + desc : ""));
     return this;
   },
   
@@ -330,8 +330,8 @@ Assertion.prototype = {
   a: function(type, desc){
     this.assert(
         type == typeof this.obj
-      , 'expected ' + this.inspect + ' to be a ' + type + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' not to be a ' + type  + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to be a ' + type + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' not to be a ' + type  + (desc ? " | " + desc : ""));
     return this;
   },
   
@@ -347,8 +347,8 @@ Assertion.prototype = {
     var name = constructor.name;
     this.assert(
         this.obj instanceof constructor
-      , 'expected ' + this.inspect + ' to be an instance of ' + name + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' not to be an instance of ' + name + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to be an instance of ' + name + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' not to be an instance of ' + name + (desc ? " | " + desc : ""));
     return this;
   },
 
@@ -363,8 +363,8 @@ Assertion.prototype = {
   above: function(n, desc){
     this.assert(
         this.obj > n
-      , 'expected ' + this.inspect + ' to be above ' + n + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' to be below ' + n + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to be above ' + n + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to be below ' + n + (desc ? " | " + desc : ""));
     return this;
   },
   
@@ -379,8 +379,8 @@ Assertion.prototype = {
   below: function(n, desc){
     this.assert(
         this.obj < n
-      , 'expected ' + this.inspect + ' to be below ' + n + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' to be above ' + n + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to be below ' + n + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to be above ' + n + (desc ? " | " + desc : ""));
     return this;
   },
   
@@ -395,8 +395,8 @@ Assertion.prototype = {
   match: function(regexp, desc){
     this.assert(
         regexp.exec(this.obj)
-      , 'expected ' + this.inspect + ' to match ' + regexp + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' not to match ' + regexp + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to match ' + regexp + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' not to match ' + regexp + (desc ? " | " + desc : ""));
     return this;
   },
   
@@ -413,8 +413,8 @@ Assertion.prototype = {
     var len = this.obj.length;
     this.assert(
         n == len
-      , 'expected ' + this.inspect + ' to have a length of ' + n + ' but got ' + len + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' to not have a length of ' + len + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to have a length of ' + n + ' but got ' + len + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not have a length of ' + len + (desc ? " | " + desc : ""));
     return this;
   },
 
@@ -430,21 +430,21 @@ Assertion.prototype = {
   property: function(name, val, desc){
     if (this.negate && undefined !== val) {
       if (undefined === this.obj[name]) {
-        throw new Error(this.inspect + ' has no property ' + i(name) + ((desc) ? " | " + desc : ""));
+        throw new Error(this.inspect + ' has no property ' + i(name) + (desc ? " | " + desc : ""));
       }
     } else {
       this.assert(
           undefined !== this.obj[name]
-        , 'expected ' + this.inspect + ' to have a property ' + i(name) + ((desc) ? " | " + desc : "")
-        , 'expected ' + this.inspect + ' to not have a property ' + i(name) + ((desc) ? " | " + desc : ""));
+        , 'expected ' + this.inspect + ' to have a property ' + i(name) + (desc ? " | " + desc : "")
+        , 'expected ' + this.inspect + ' to not have a property ' + i(name) + (desc ? " | " + desc : ""));
     }
     
     if (undefined !== val) {
       this.assert(
           val === this.obj[name]
         , 'expected ' + this.inspect + ' to have a property ' + i(name)
-          + ' of ' + i(val) + ', but got ' + i(this.obj[name]) + ((desc) ? " | " + desc : "")
-        , 'expected ' + this.inspect + ' to not have a property ' + i(name) + ' of ' + i(val) + ((desc) ? " | " + desc : ""));
+          + ' of ' + i(val) + ', but got ' + i(this.obj[name]) + (desc ? " | " + desc : "")
+        , 'expected ' + this.inspect + ' to not have a property ' + i(name) + ' of ' + i(val) + (desc ? " | " + desc : ""));
     }
 
     this.obj = this.obj[name];
@@ -462,8 +462,8 @@ Assertion.prototype = {
   ownProperty: function(name, desc){
     this.assert(
         this.obj.hasOwnProperty(name)
-      , 'expected ' + this.inspect + ' to have own property ' + i(name) + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' to not have own property ' + i(name) + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to have own property ' + i(name) + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not have own property ' + i(name) + (desc ? " | " + desc : ""));
     return this;
   },
 
@@ -478,8 +478,8 @@ Assertion.prototype = {
   include: function(obj, desc){
     this.assert(
         ~this.obj.indexOf(obj)
-      , 'expected ' + this.inspect + ' to include ' + i(obj) + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' to not include ' + i(obj) + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to include ' + i(obj) + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not include ' + i(obj) + (desc ? " | " + desc : ""));
 
     return this;
   },
@@ -495,8 +495,8 @@ Assertion.prototype = {
   includeEql: function(obj, desc){
     this.assert(
       this.obj.some(function(item) { return eql(obj, item); })
-      , 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) + ((desc) ? " | " + desc : "")
-      , 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) + ((desc) ? " | " + desc : ""));
+      , 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) + (desc ? " | " + desc : ""));
     return this;
   },
 
@@ -650,8 +650,8 @@ Assertion.prototype = {
 
     this.assert(
         ok
-      , 'expected an exception to be thrown' + ((desc) ? " | " + desc : "")
-      , 'expected no exception to be thrown, got "' + err.message + '"' + ((desc) ? " | " + desc : ""));
+      , 'expected an exception to be thrown' + (desc ? " | " + desc : "")
+      , 'expected no exception to be thrown, got "' + err.message + '"' + (desc ? " | " + desc : ""));
 
     return this;
   }

--- a/lib/should.js
+++ b/lib/should.js
@@ -273,14 +273,15 @@ Assertion.prototype = {
    * Assert equal. 
    *
    * @param {Mixed} val
+   * @param {String} description
    * @api public
    */
   
-  eql: function(val){
+  eql: function(val, desc){
     this.assert(
         eql(val, this.obj)
-      , 'expected ' + this.inspect + ' to equal ' + i(val)
-      , 'expected ' + this.inspect + ' to not equal ' + i(val));
+      , 'expected ' + this.inspect + ' to equal ' + i(val) + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not equal ' + i(val) + ((desc) ? " | " + desc : ""));
     return this;
   },
   
@@ -288,14 +289,15 @@ Assertion.prototype = {
    * Assert strict equal. 
    *
    * @param {Mixed} val
+   * @param {String} description
    * @api public
    */
   
-  equal: function(val){
+  equal: function(val, desc){
     this.assert(
         val === this.obj
-      , 'expected ' + this.inspect + ' to equal ' + i(val)
-      , 'expected ' + this.inspect + ' to not equal ' + i(val));
+      , 'expected ' + this.inspect + ' to equal ' + i(val) + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not equal ' + i(val) + ((desc) ? " | " + desc : ""));
     return this;
   },
   
@@ -304,44 +306,49 @@ Assertion.prototype = {
    *
    * @param {Number} start
    * @param {Number} finish
+   * @param {String} description
    * @api public
    */
   
-  within: function(start, finish){
+  within: function(start, finish, desc){
     var range = start + '..' + finish;
     this.assert(
         this.obj >= start && this.obj <= finish
-      , 'expected ' + this.inspect + ' to be within ' + range
-      , 'expected ' + this.inspect + ' to not be within ' + range);
+      , 'expected ' + this.inspect + ' to be within ' + range + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not be within ' + range + ((desc) ? " | " + desc : ""));
     return this;
   },
   
   /**
    * Assert typeof. 
    *
+   * @param {Mixed} type
+   * @param {String} description
    * @api public
    */
   
-  a: function(type){
+  a: function(type, desc){
     this.assert(
         type == typeof this.obj
-      , 'expected ' + this.inspect + ' to be a ' + type
-      , 'expected ' + this.inspect + ' not to be a ' + type);
+      , 'expected ' + this.inspect + ' to be a ' + type + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' not to be a ' + type  + ((desc) ? " | " + desc : ""));
     return this;
   },
   
   /**
    * Assert instanceof. 
    *
+   * @param {Function} constructor
+   * @param {String} description
    * @api public
    */
   
-  instanceof: function(constructor){
+  instanceof: function(constructor, desc){
     var name = constructor.name;
     this.assert(
         this.obj instanceof constructor
-      , 'expected ' + this.inspect + ' to be an instance of ' + name
-      , 'expected ' + this.inspect + ' not to be an instance of ' + name);
+      , 'expected ' + this.inspect + ' to be an instance of ' + name + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' not to be an instance of ' + name + ((desc) ? " | " + desc : ""));
     return this;
   },
 
@@ -349,14 +356,15 @@ Assertion.prototype = {
    * Assert numeric value above _n_.
    *
    * @param {Number} n
+   * @param {String} description
    * @api public
    */
   
-  above: function(n){
+  above: function(n, desc){
     this.assert(
         this.obj > n
-      , 'expected ' + this.inspect + ' to be above ' + n
-      , 'expected ' + this.inspect + ' to be below ' + n);
+      , 'expected ' + this.inspect + ' to be above ' + n + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to be below ' + n + ((desc) ? " | " + desc : ""));
     return this;
   },
   
@@ -364,14 +372,15 @@ Assertion.prototype = {
    * Assert numeric value below _n_.
    *
    * @param {Number} n
+   * @param {String} description
    * @api public
    */
   
-  below: function(n){
+  below: function(n, desc){
     this.assert(
         this.obj < n
-      , 'expected ' + this.inspect + ' to be below ' + n
-      , 'expected ' + this.inspect + ' to be above ' + n);
+      , 'expected ' + this.inspect + ' to be below ' + n + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to be above ' + n + ((desc) ? " | " + desc : ""));
     return this;
   },
   
@@ -379,14 +388,15 @@ Assertion.prototype = {
    * Assert string value matches _regexp_.
    *
    * @param {RegExp} regexp
+   * @param {String} description
    * @api public
    */
   
-  match: function(regexp){
+  match: function(regexp, desc){
     this.assert(
         regexp.exec(this.obj)
-      , 'expected ' + this.inspect + ' to match ' + regexp
-      , 'expected ' + this.inspect + ' not to match ' + regexp);
+      , 'expected ' + this.inspect + ' to match ' + regexp + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' not to match ' + regexp + ((desc) ? " | " + desc : ""));
     return this;
   },
   
@@ -394,16 +404,17 @@ Assertion.prototype = {
    * Assert property "length" exists and has value of _n_.
    *
    * @param {Number} n
+   * @param {String} description
    * @api public
    */
   
-  length: function(n){
+  length: function(n, desc){
     this.obj.should.have.property('length');
     var len = this.obj.length;
     this.assert(
         n == len
-      , 'expected ' + this.inspect + ' to have a length of ' + n + ' but got ' + len
-      , 'expected ' + this.inspect + ' to not have a length of ' + len);
+      , 'expected ' + this.inspect + ' to have a length of ' + n + ' but got ' + len + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not have a length of ' + len + ((desc) ? " | " + desc : ""));
     return this;
   },
 
@@ -412,27 +423,28 @@ Assertion.prototype = {
    *
    * @param {String} name
    * @param {Mixed} val
+   * @param {String} description
    * @api public
    */
   
-  property: function(name, val){
+  property: function(name, val, desc){
     if (this.negate && undefined !== val) {
       if (undefined === this.obj[name]) {
-        throw new Error(this.inspect + ' has no property ' + i(name));
+        throw new Error(this.inspect + ' has no property ' + i(name) + ((desc) ? " | " + desc : ""));
       }
     } else {
       this.assert(
           undefined !== this.obj[name]
-        , 'expected ' + this.inspect + ' to have a property ' + i(name)
-        , 'expected ' + this.inspect + ' to not have a property ' + i(name));
+        , 'expected ' + this.inspect + ' to have a property ' + i(name) + ((desc) ? " | " + desc : "")
+        , 'expected ' + this.inspect + ' to not have a property ' + i(name) + ((desc) ? " | " + desc : ""));
     }
     
     if (undefined !== val) {
       this.assert(
           val === this.obj[name]
         , 'expected ' + this.inspect + ' to have a property ' + i(name)
-          + ' of ' + i(val) + ', but got ' + i(this.obj[name])
-        , 'expected ' + this.inspect + ' to not have a property ' + i(name) + ' of ' + i(val));
+          + ' of ' + i(val) + ', but got ' + i(this.obj[name]) + ((desc) ? " | " + desc : "")
+        , 'expected ' + this.inspect + ' to not have a property ' + i(name) + ' of ' + i(val) + ((desc) ? " | " + desc : ""));
     }
 
     this.obj = this.obj[name];
@@ -443,14 +455,15 @@ Assertion.prototype = {
    * Assert own property _name_ exists.
    *
    * @param {String} name
+   * @param {String} description
    * @api public
    */
   
-  ownProperty: function(name){
+  ownProperty: function(name, desc){
     this.assert(
         this.obj.hasOwnProperty(name)
-      , 'expected ' + this.inspect + ' to have own property ' + i(name)
-      , 'expected ' + this.inspect + ' to not have own property ' + i(name));
+      , 'expected ' + this.inspect + ' to have own property ' + i(name) + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not have own property ' + i(name) + ((desc) ? " | " + desc : ""));
     return this;
   },
 
@@ -458,14 +471,15 @@ Assertion.prototype = {
    * Assert that `obj` is present via `.indexOf()`.
    *
    * @param {Mixed} obj
+   * @param {String} description
    * @api public
    */
 
-  include: function(obj){
+  include: function(obj, desc){
     this.assert(
         ~this.obj.indexOf(obj)
-      , 'expected ' + this.inspect + ' to include ' + i(obj)
-      , 'expected ' + this.inspect + ' to not include ' + i(obj));
+      , 'expected ' + this.inspect + ' to include ' + i(obj) + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not include ' + i(obj) + ((desc) ? " | " + desc : ""));
 
     return this;
   },
@@ -474,14 +488,15 @@ Assertion.prototype = {
    * Assert that an object equal to `obj` is present.
    *
    * @param {Array} obj
+   * @param {String} description
    * @api public
    */
 
-  includeEql: function(obj){
+  includeEql: function(obj, desc){
     this.assert(
       this.obj.some(function(item) { return eql(obj, item); })
-      , 'expected ' + this.inspect + ' to include an object equal to ' + i(obj)
-      , 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj));
+      , 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) + ((desc) ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) + ((desc) ? " | " + desc : ""));
     return this;
   },
 
@@ -616,11 +631,12 @@ Assertion.prototype = {
    * Assert that this function will or will not
    * throw an exception.
    *
+   * @param {String} description
    * @return {Assertion} for chaining
    * @api public
    */
 
-  throw: function(){
+  throw: function(desc){
     var fn = this.obj
       , err = {}
       , ok = true;
@@ -634,8 +650,8 @@ Assertion.prototype = {
 
     this.assert(
         ok
-      , 'expected an exception to be thrown'
-      , 'expected no exception to be thrown, got "' + err.message + '"');
+      , 'expected an exception to be thrown' + ((desc) ? " | " + desc : "")
+      , 'expected no exception to be thrown, got "' + err.message + '"' + ((desc) ? " | " + desc : ""));
 
     return this;
   }

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -80,12 +80,20 @@ module.exports = {
     err(function(){
       'test'.should.not.be.a('string');
     }, "expected 'test' not to be a string");
+
+    err(function(){
+      'test'.should.not.be.a('string', 'foo');
+    }, "expected 'test' not to be a string | foo");
     
     (5).should.be.a('number');
 
     err(function(){
       (5).should.not.be.a('number');
     }, "expected 5 not to be a number");
+
+    err(function(){
+      (5).should.not.be.a('number', 'foo');
+    }, "expected 5 not to be a number | foo");
   },
   
   'test instanceof': function(){
@@ -95,6 +103,10 @@ module.exports = {
     err(function(){
       (3).should.an.instanceof(Foo);
     }, "expected 3 to be an instance of Foo");
+
+    err(function(){
+      (3).should.an.instanceof(Foo, 'foo');
+    }, "expected 3 to be an instance of Foo | foo");
   },
   
   'test within(start, finish)': function(){
@@ -110,6 +122,14 @@ module.exports = {
     err(function(){
       (10).should.be.within(50,100);
     }, "expected 10 to be within 50..100");
+
+    err(function(){
+      (5).should.not.be.within(4,6, 'foo');
+    }, "expected 5 to not be within 4..6 | foo");
+
+    err(function(){
+      (10).should.be.within(50,100, 'foo');
+    }, "expected 10 to be within 50..100 | foo");
   },
   
   'test above(n)': function(){
@@ -125,6 +145,37 @@ module.exports = {
     err(function(){
       (10).should.not.be.above(6);
     }, "expected 10 to be below 6");
+
+    err(function(){
+      (5).should.be.above(6, 'foo');
+    }, "expected 5 to be above 6 | foo");
+    
+    err(function(){
+      (10).should.not.be.above(6, 'foo');
+    }, "expected 10 to be below 6 | foo");
+  },
+
+  'test below(n)': function(){
+    (2).should.be.below(5);
+    (2).should.be.lessThan(5);
+    (5).should.not.be.below(5);
+    (6).should.not.be.below(5);
+
+    err(function(){
+      (6).should.be.below(5);
+    }, "expected 6 to be below 5");
+    
+    err(function(){
+      (6).should.not.be.below(10);
+    }, "expected 6 to be above 10");
+
+    err(function(){
+      (6).should.be.below(5, 'foo');
+    }, "expected 6 to be below 5 | foo");
+    
+    err(function(){
+      (6).should.not.be.below(10, 'foo');
+    }, "expected 6 to be above 10 | foo");
   },
   
   'test match(regexp)': function(){
@@ -138,6 +189,14 @@ module.exports = {
     err(function(){
       'foobar'.should.not.match(/^foo/i)
     }, "expected 'foobar' not to match /^foo/i");
+
+    err(function(){
+      'foobar'.should.match(/^bar/i, 'foo')
+    }, "expected 'foobar' to match /^bar/i | foo");
+    
+    err(function(){
+      'foobar'.should.not.match(/^foo/i, 'foo')
+    }, "expected 'foobar' not to match /^foo/i | foo");
   },
   
   'test length(n)': function(){
@@ -152,6 +211,15 @@ module.exports = {
     err(function(){
       'asd'.should.not.have.length(3);
     }, "expected 'asd' to not have a length of 3");
+
+    err(function(){
+      'asd'.should.have.length(4, 'foo');
+    }, "expected 'asd' to have a length of 4 but got 3 | foo");
+    
+    err(function(){
+      'asd'.should.not.have.length(3, 'foo');
+    }, "expected 'asd' to not have a length of 3 | foo");
+
   },
   
   'test eql(val)': function(){
@@ -163,6 +231,14 @@ module.exports = {
     err(function(){
       (4).should.eql(3);
     }, 'expected 4 to equal 3');
+
+    err(function(){
+      (4).should.eql(3, "foo");
+    }, 'expected 4 to equal 3 | foo');
+
+    err(function(){
+      (3).should.not.eql(3, "foo");
+    }, 'expected 3 to not equal 3 | foo');
   },
   
   'test equal(val)': function(){
@@ -176,6 +252,14 @@ module.exports = {
     err(function(){
       '4'.should.equal(4);
     }, "expected '4' to equal 4");
+
+    err(function(){
+      (3).should.equal(4, "foo");
+    }, "expected 3 to equal 4 | foo");
+
+    err(function(){
+      (4).should.not.equal(4, "foo");
+    }, "expected 4 to not equal 4 | foo");
   },
   
   'test empty': function(){
@@ -203,6 +287,14 @@ module.exports = {
     err(function(){
       'asd'.should.have.property('foo');
     }, "expected 'asd' to have a property 'foo'");
+
+    err(function(){
+      'asd'.should.have.property('foo', undefined, 'foo');
+    }, "expected 'asd' to have a property 'foo' | foo");
+
+    err(function(){
+      'asd'.should.not.have.property('length', undefined, 'foo');
+    }, "expected 'asd' to not have a property 'length' | foo");
   },
   
   'test property(name, val)': function(){
@@ -224,6 +316,22 @@ module.exports = {
     err(function(){
       'asd'.should.have.property('constructor', Number);
     }, "expected 'asd' to have a property 'constructor' of [Function: Number], but got [Function: String]");
+
+    err(function(){
+      'asd'.should.have.property('length', 4, 'foo');
+    }, "expected 'asd' to have a property 'length' of 4, but got 3 | foo");
+    
+    err(function(){
+      'asd'.should.not.have.property('length', 3, 'foo');
+    }, "expected 'asd' to not have a property 'length' of 3 | foo");
+    
+    err(function(){
+      'asd'.should.not.have.property('foo', 3, 'foo');
+    }, "'asd' has no property 'foo' | foo");
+    
+    err(function(){
+      'asd'.should.have.property('constructor', Number, 'foo');
+    }, "expected 'asd' to have a property 'constructor' of [Function: Number], but got [Function: String] | foo");
   },
   
   'test ownProperty(name)': function(){
@@ -234,6 +342,14 @@ module.exports = {
     err(function(){
       ({ length: 12 }).should.not.have.ownProperty('length');
     }, "expected { length: 12 } to not have own property 'length'");
+
+    err(function(){
+      ({ length: 12 }).should.not.have.ownProperty('length', 'foo');
+    }, "expected { length: 12 } to not have own property 'length' | foo");
+
+    err(function(){
+      ({ length: 12 }).should.have.ownProperty('foo', 'foo');
+    }, "expected { length: 12 } to have own property 'foo' | foo");
   },
 
   'test include() with string': function(){
@@ -248,6 +364,14 @@ module.exports = {
     err(function(){
       'foobar'.should.not.include('bar');
     }, "expected 'foobar' to not include 'bar'");
+
+    err(function(){
+      'foobar'.should.include('baz', 'foo');
+    }, "expected 'foobar' to include 'baz' | foo");
+    
+    err(function(){
+      'foobar'.should.not.include('bar', 'foo');
+    }, "expected 'foobar' to not include 'bar' | foo");
   },
 
   'test include() with array': function(){
@@ -265,6 +389,14 @@ module.exports = {
     err(function(){
       ['bar', 'foo'].should.not.include('foo');
     }, "expected [ 'bar', 'foo' ] to not include 'foo'");
+
+    err(function(){
+      ['foo'].should.include('bar', 'foo');
+    }, "expected [ 'foo' ] to include 'bar' | foo");
+    
+    err(function(){
+      ['bar', 'foo'].should.not.include('foo', 'foo');
+    }, "expected [ 'bar', 'foo' ] to not include 'foo' | foo");
   },
   
   'test includeEql() with array': function(){
@@ -280,6 +412,14 @@ module.exports = {
     err(function(){
       [['foo']].should.not.includeEql(['foo']);
     }, "expected [ [ 'foo' ] ] to not include an object equal to [ 'foo' ]");
+
+    err(function(){
+      [['foo']].should.includeEql(['bar'], 'foo');
+    }, "expected [ [ 'foo' ] ] to include an object equal to [ 'bar' ] | foo");
+    
+    err(function(){
+      [['foo']].should.not.includeEql(['foo'], 'foo');
+    }, "expected [ [ 'foo' ] ] to not include an object equal to [ 'foo' ] | foo");
   },
   
   'test keys(array)': function(){
@@ -348,5 +488,15 @@ module.exports = {
         throw new Error('fail');
       }).should.not.throw();
     }, 'expected no exception to be thrown, got "fail"');
+
+    err(function(){
+      (function(){}).should.throw("foo");
+    }, 'expected an exception to be thrown | foo');
+
+    err(function(){
+      (function(){
+        throw new Error('fail');
+      }).should.not.throw('foo');
+    }, 'expected no exception to be thrown, got "fail" | foo');
   }
 };


### PR DESCRIPTION
In a lot of my tests I was getting cryptic errors like "expected 1 to equal 0" without any indication of where the failure was really coming from. I added an optional failure description to several should matchers so the process of hunting down and fixing bugs would be a lot faster. Also, anyone reading through my tests can quickly figure out exactly what I was trying to test.

I added it to almost all of the methods that were functional properties except `keys` because I haven't figured out a clean way to do it yet. Also, would like to add optional failure message to the getters but I haven't quite figured that one out yet either.

Check out this example bellow and let me know if you have any questions.

Example:

```
(1).should.eql(0, 'some useful description')

AssertionError: expected 1 to equal 0 | some useful description
  at Object.eql (/Users/swift/code/should.js/node_modules/should/lib/should.js:280:10)
  ...
```

The methods that support this optional description are: `eql`, `equal`, `within`, `a`, `instanceof`, `above`, `below`, `match`, `length`, `property`, `ownProperty`, `include`, `includeEql`, and `throw`.
