### PR TITLE
Adding a message matching param to throw()

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -640,7 +640,7 @@ Assertion.prototype = {
       }
 
       if (message && !ok) {
-        errorInfo = ' matching \'' + message + '\'';
+        errorInfo = " with a message matching '" + message + "', but got '" + err.message +"'";
       }
     }
 

--- a/lib/should.js
+++ b/lib/should.js
@@ -619,10 +619,10 @@ Assertion.prototype = {
    * @return {Assertion} for chaining
    * @api public
    */
-
-  throw: function(){
+  throw: function(message){
     var fn = this.obj
       , err = {}
+      , errorInfo = ''
       , ok = true;
 
     try {
@@ -632,9 +632,19 @@ Assertion.prototype = {
       err = e;
     }
 
+    if (typeof message === 'string') {
+      ok = message === err.message;
+    } else if (message instanceof RegExp) {
+      ok = message.test(err.message);
+    }
+
+    if (message && !ok) {
+      errorInfo = ' matching \'' + message + '\'';
+    }
+
     this.assert(
         ok
-      , 'expected an exception to be thrown'
+      , 'expected an exception to be thrown' + errorInfo
       , 'expected no exception to be thrown, got "' + err.message + '"');
 
     return this;

--- a/lib/should.js
+++ b/lib/should.js
@@ -632,14 +632,16 @@ Assertion.prototype = {
       err = e;
     }
 
-    if (typeof message === 'string') {
-      ok = message === err.message;
-    } else if (message instanceof RegExp) {
-      ok = message.test(err.message);
-    }
+    if (ok) {
+      if (typeof message === 'string') {
+        ok = message === err.message;
+      } else if (message instanceof RegExp) {
+        ok = message.test(err.message);
+      }
 
-    if (message && !ok) {
-      errorInfo = ' matching \'' + message + '\'';
+      if (message && !ok) {
+        errorInfo = ' matching \'' + message + '\'';
+      }
     }
 
     this.assert(

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -355,7 +355,7 @@ module.exports = {
 
     err(function(){
       (function(){}).should.throw(/fail/);
-    }, 'expected an exception to be thrown matching \'/fail/\'');
+    }, 'expected an exception to be thrown');
 
     err(function(){
       (function(){ throw new Error('error'); }).should.throw(/fail/);
@@ -367,7 +367,19 @@ module.exports = {
 
     err(function(){
       (function(){}).should.throw('fail');
+    }, 'expected an exception to be thrown');
+
+    err(function(){
+      (function(){ throw new Error('error'); }).should.throw('fail');
     }, 'expected an exception to be thrown matching \'fail\'');
+  },
+
+  'test throw() with string message': function(){
+    (function(){ throw new Error('fail'); }).should.throw('fail');
+
+    err(function(){
+      (function(){}).should.throw('fail');
+    }, 'expected an exception to be thrown');
 
     err(function(){
       (function(){ throw new Error('error'); }).should.throw('fail');

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -348,5 +348,29 @@ module.exports = {
         throw new Error('fail');
       }).should.not.throw();
     }, 'expected no exception to be thrown, got "fail"');
+  },
+
+  'test throw() with regex message': function(){
+    (function(){ throw new Error('fail'); }).should.throw(/fail/);
+
+    err(function(){
+      (function(){}).should.throw(/fail/);
+    }, 'expected an exception to be thrown matching \'/fail/\'');
+
+    err(function(){
+      (function(){ throw new Error('error'); }).should.throw(/fail/);
+    }, 'expected an exception to be thrown matching \'/fail/\'');
+  },
+
+  'test throw() with string message': function(){
+    (function(){ throw new Error('fail'); }).should.throw('fail');
+
+    err(function(){
+      (function(){}).should.throw('fail');
+    }, 'expected an exception to be thrown matching \'fail\'');
+
+    err(function(){
+      (function(){ throw new Error('error'); }).should.throw('fail');
+    }, 'expected an exception to be thrown matching \'fail\'');
   }
 };

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -359,7 +359,7 @@ module.exports = {
 
     err(function(){
       (function(){ throw new Error('error'); }).should.throw(/fail/);
-    }, 'expected an exception to be thrown matching \'/fail/\'');
+    }, "expected an exception to be thrown with a message matching '/fail/', but got 'error'");
   },
 
   'test throw() with string message': function(){
@@ -371,18 +371,6 @@ module.exports = {
 
     err(function(){
       (function(){ throw new Error('error'); }).should.throw('fail');
-    }, 'expected an exception to be thrown matching \'fail\'');
-  },
-
-  'test throw() with string message': function(){
-    (function(){ throw new Error('fail'); }).should.throw('fail');
-
-    err(function(){
-      (function(){}).should.throw('fail');
-    }, 'expected an exception to be thrown');
-
-    err(function(){
-      (function(){ throw new Error('error'); }).should.throw('fail');
-    }, 'expected an exception to be thrown matching \'fail\'');
+    }, "expected an exception to be thrown with a message matching 'fail', but got 'error'");
   }
-};
+}; 


### PR DESCRIPTION
I added a message parameter to throw() to allow assertions on the error message thrown

A bit like 'message' in the default assert.throws(block, [error], [message])

http://nodejs.org/docs/v0.6.7/api/assert.html#assert.throws

Tests also included
