### PR TITLE
Return 'this' in get json/get html in order to provide chaining as expected.

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -616,6 +616,7 @@ Assertion.prototype = {
     this.obj.should.have.property('headers');
     this.obj.headers.should.have.property('content-type');
     this.obj.headers['content-type'].should.include('application/json');
+    return this;
   },
 
   /**
@@ -629,6 +630,7 @@ Assertion.prototype = {
     this.obj.should.have.property('headers');
     this.obj.headers.should.have.property('content-type');
     this.obj.headers['content-type'].should.include('text/html');
+    return this;
   },
 
   /**


### PR DESCRIPTION
I had problems when chaining should.be.json, e.g. res.should.be.json.and.have.status(200), because should.be.json returned 'undefined' in the case of res being json. Adding 'return this' to 'get json' and 'get html' seems to fix this.
