### PR TITLE
Proposing a fallback of `.instanceof` as `.instanceOf`

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -18,7 +18,7 @@ var util = require('util')
 
 /**
  * Expose assert as should.
- * 
+ *
  * This allows you to do things like below
  * without require()ing the assert module.
  *
@@ -41,7 +41,7 @@ exports.version = '0.6.0';
  * @param {String} msg
  * @api public
  */
- 
+
 exports.exist = function(obj, msg){
   if (null == obj) {
     throw new AssertionError({
@@ -103,7 +103,7 @@ Assertion.prototype = {
   /**
    * HACK: prevents double require() from failing.
    */
-  
+
   exports: exports,
 
   /**
@@ -135,27 +135,27 @@ Assertion.prototype = {
    *
    * @api public
    */
-  
+
   get an() {
     return this;
   },
-  
+
   /**
    * Dummy getter.
    *
    * @api public
    */
-  
+
   get and() {
     return this;
   },
-  
+
   /**
    * Dummy getter.
    *
    * @api public
    */
-  
+
   get be() {
     return this;
   },
@@ -165,39 +165,39 @@ Assertion.prototype = {
    *
    * @api public
    */
-  
+
   get have() {
     return this;
   },
-  
+
   /**
    * Dummy getter.
    *
    * @api public
    */
-  
+
   get with() {
     return this;
   },
-  
+
   /**
    * Negation modifier.
    *
    * @api public
    */
-  
+
   get not() {
     this.negate = true;
     return this;
   },
-  
+
   /**
    * Get object inspection string.
    *
    * @return {String}
    * @api private
    */
-  
+
   get inspect() {
     return i(this.obj);
   },
@@ -221,7 +221,7 @@ Assertion.prototype = {
    *
    * @api public
    */
-  
+
   get empty() {
     this.obj.should.have.property('length');
     this.assert(
@@ -236,7 +236,7 @@ Assertion.prototype = {
    *
    * @api public
    */
-  
+
   get ok() {
     this.assert(
         this.obj
@@ -244,13 +244,13 @@ Assertion.prototype = {
       , 'expected ' + this.inspect + ' to be falsey');
     return this;
   },
-  
+
   /**
    * Assert true.
    *
    * @api public
    */
-  
+
   get true() {
     this.assert(
         true === this.obj
@@ -258,13 +258,13 @@ Assertion.prototype = {
       , 'expected ' + this.inspect + ' not to be true');
     return this;
   },
-  
+
   /**
    * Assert false.
    *
    * @api public
    */
-  
+
   get false() {
     this.assert(
         false === this.obj
@@ -272,15 +272,15 @@ Assertion.prototype = {
       , 'expected ' + this.inspect + ' not to be false');
     return this;
   },
-  
+
   /**
-   * Assert equal. 
+   * Assert equal.
    *
    * @param {Mixed} val
    * @param {String} description
    * @api public
    */
-  
+
   eql: function(val, desc){
     this.assert(
         eql(val, this.obj)
@@ -289,15 +289,15 @@ Assertion.prototype = {
       , val);
     return this;
   },
-  
+
   /**
-   * Assert strict equal. 
+   * Assert strict equal.
    *
    * @param {Mixed} val
    * @param {String} description
    * @api public
    */
-  
+
   equal: function(val, desc){
     this.assert(
         val === this.obj
@@ -306,16 +306,16 @@ Assertion.prototype = {
       , val);
     return this;
   },
-  
+
   /**
-   * Assert within start to finish (inclusive). 
+   * Assert within start to finish (inclusive).
    *
    * @param {Number} start
    * @param {Number} finish
    * @param {String} description
    * @api public
    */
-  
+
   within: function(start, finish, desc){
     var range = start + '..' + finish;
     this.assert(
@@ -324,15 +324,15 @@ Assertion.prototype = {
       , 'expected ' + this.inspect + ' to not be within ' + range + (desc ? " | " + desc : ""));
     return this;
   },
-  
+
   /**
-   * Assert typeof. 
+   * Assert typeof.
    *
    * @param {Mixed} type
    * @param {String} description
    * @api public
    */
-  
+
   a: function(type, desc){
     this.assert(
         type == typeof this.obj
@@ -340,15 +340,15 @@ Assertion.prototype = {
       , 'expected ' + this.inspect + ' not to be a ' + type  + (desc ? " | " + desc : ""));
     return this;
   },
-  
+
   /**
-   * Assert instanceof. 
+   * Assert instanceof.
    *
    * @param {Function} constructor
    * @param {String} description
    * @api public
    */
-  
+
   instanceof: function(constructor, desc){
     var name = constructor.name;
     this.assert(
@@ -365,7 +365,7 @@ Assertion.prototype = {
    * @param {String} description
    * @api public
    */
-  
+
   above: function(n, desc){
     this.assert(
         this.obj > n
@@ -373,7 +373,7 @@ Assertion.prototype = {
       , 'expected ' + this.inspect + ' to be below ' + n + (desc ? " | " + desc : ""));
     return this;
   },
-  
+
   /**
    * Assert numeric value below _n_.
    *
@@ -381,7 +381,7 @@ Assertion.prototype = {
    * @param {String} description
    * @api public
    */
-  
+
   below: function(n, desc){
     this.assert(
         this.obj < n
@@ -389,7 +389,7 @@ Assertion.prototype = {
       , 'expected ' + this.inspect + ' to be above ' + n + (desc ? " | " + desc : ""));
     return this;
   },
-  
+
   /**
    * Assert string value matches _regexp_.
    *
@@ -397,7 +397,7 @@ Assertion.prototype = {
    * @param {String} description
    * @api public
    */
-  
+
   match: function(regexp, desc){
     this.assert(
         regexp.exec(this.obj)
@@ -405,7 +405,7 @@ Assertion.prototype = {
       , 'expected ' + this.inspect + ' not to match ' + regexp + (desc ? " | " + desc : ""));
     return this;
   },
-  
+
   /**
    * Assert property "length" exists and has value of _n_.
    *
@@ -413,7 +413,7 @@ Assertion.prototype = {
    * @param {String} description
    * @api public
    */
-  
+
   length: function(n, desc){
     this.obj.should.have.property('length');
     var len = this.obj.length;
@@ -432,7 +432,7 @@ Assertion.prototype = {
    * @param {String} description
    * @api public
    */
-  
+
   property: function(name, val, desc){
     if (this.negate && undefined !== val) {
       if (undefined === this.obj[name]) {
@@ -444,7 +444,7 @@ Assertion.prototype = {
         , 'expected ' + this.inspect + ' to have a property ' + i(name) + (desc ? " | " + desc : "")
         , 'expected ' + this.inspect + ' to not have a property ' + i(name) + (desc ? " | " + desc : ""));
     }
-    
+
     if (undefined !== val) {
       this.assert(
           val === this.obj[name]
@@ -456,7 +456,7 @@ Assertion.prototype = {
     this.obj = this.obj[name];
     return this;
   },
-  
+
   /**
    * Assert own property _name_ exists.
    *
@@ -464,7 +464,7 @@ Assertion.prototype = {
    * @param {String} description
    * @api public
    */
-  
+
   ownProperty: function(name, desc){
     this.assert(
         this.obj.hasOwnProperty(name)
@@ -489,7 +489,7 @@ Assertion.prototype = {
 
     return this;
   },
-  
+
   /**
    * Assert that an object equal to `obj` is present.
    *
@@ -522,7 +522,7 @@ Assertion.prototype = {
       , 'expected ' + this.inspect + ' to not contain ' + i(obj));
     return this;
   },
-  
+
   /**
    * Assert exact keys or inclusion of keys by using
    * the `.include` modifier.
@@ -530,7 +530,7 @@ Assertion.prototype = {
    * @param {Array|String ...} keys
    * @api public
    */
-  
+
   keys: function(keys){
     var str
       , ok = true;
@@ -573,9 +573,9 @@ Assertion.prototype = {
 
     return this;
   },
-  
+
   /**
-   * Assert that header `field` has the given `val`. 
+   * Assert that header `field` has the given `val`.
    *
    * @param {String} field
    * @param {String} val
@@ -589,7 +589,7 @@ Assertion.prototype = {
       .have.property(field.toLowerCase(), val);
     return this;
   },
-  
+
   /**
    * Assert `.statusCode` of `code`.
    *

--- a/lib/should.js
+++ b/lib/should.js
@@ -684,7 +684,7 @@ Assertion.prototype = {
     return this;
   }
 };
-
+Assertion.prototype.instanceOf = Assertion.prototype.instanceof;
 /**
  * Aliases.
  */

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -28,37 +28,37 @@ module.exports = {
     'test'.should.be.a.string;
     should.equal('foo', 'foo');
   },
-  
+
   'test true': function(){
     true.should.be.true;
     false.should.not.be.true;
     (1).should.not.be.true;
-    
+
     err(function(){
       'test'.should.be.true;
     }, "expected 'test' to be true")
   },
-  
+
   'test ok': function(){
     true.should.be.ok;
     false.should.not.be.ok;
     (1).should.be.ok;
     (0).should.not.be.ok;
-    
+
     err(function(){
       ''.should.be.ok;
     }, "expected '' to be truthy");
-    
+
     err(function(){
       'test'.should.not.be.ok;
     }, "expected 'test' to be falsey");
   },
-  
+
   'test false': function(){
     false.should.be.false;
     true.should.not.be.false;
     (0).should.not.be.false;
-    
+
     err(function(){
       ''.should.be.false;
     }, "expected '' to be false")
@@ -78,12 +78,12 @@ module.exports = {
     args.should.be.arguments;
     [].should.not.be.arguments;
   },
-  
+
   'test .equal()': function(){
     var foo;
     should.equal(undefined, foo);
   },
-  
+
   'test typeof': function(){
     'test'.should.be.a('string');
 
@@ -94,7 +94,7 @@ module.exports = {
     err(function(){
       'test'.should.not.be.a('string', 'foo');
     }, "expected 'test' not to be a string | foo");
-    
+
     (5).should.be.a('number');
 
     err(function(){
@@ -105,7 +105,7 @@ module.exports = {
       (5).should.not.be.a('number', 'foo');
     }, "expected 5 not to be a number | foo");
   },
-  
+
   'test instanceof': function(){
     function Foo(){}
     new Foo().should.be.an.instanceof(Foo);
@@ -118,17 +118,17 @@ module.exports = {
       (3).should.an.instanceof(Foo, 'foo');
     }, "expected 3 to be an instance of Foo | foo");
   },
-  
+
   'test within(start, finish)': function(){
     (5).should.be.within(5, 10);
     (5).should.be.within(3,6);
     (5).should.be.within(3,5);
     (5).should.not.be.within(1,3);
-    
+
     err(function(){
       (5).should.not.be.within(4,6);
     }, "expected 5 to not be within 4..6");
-    
+
     err(function(){
       (10).should.be.within(50,100);
     }, "expected 10 to be within 50..100");
@@ -141,7 +141,7 @@ module.exports = {
       (10).should.be.within(50,100, 'foo');
     }, "expected 10 to be within 50..100 | foo");
   },
-  
+
   'test above(n)': function(){
     (5).should.be.above(2);
     (5).should.be.greaterThan(2);
@@ -151,7 +151,7 @@ module.exports = {
     err(function(){
       (5).should.be.above(6);
     }, "expected 5 to be above 6");
-    
+
     err(function(){
       (10).should.not.be.above(6);
     }, "expected 10 to be below 6");
@@ -159,7 +159,7 @@ module.exports = {
     err(function(){
       (5).should.be.above(6, 'foo');
     }, "expected 5 to be above 6 | foo");
-    
+
     err(function(){
       (10).should.not.be.above(6, 'foo');
     }, "expected 10 to be below 6 | foo");
@@ -174,7 +174,7 @@ module.exports = {
     err(function(){
       (6).should.be.below(5);
     }, "expected 6 to be below 5");
-    
+
     err(function(){
       (6).should.not.be.below(10);
     }, "expected 6 to be above 10");
@@ -182,20 +182,20 @@ module.exports = {
     err(function(){
       (6).should.be.below(5, 'foo');
     }, "expected 6 to be below 5 | foo");
-    
+
     err(function(){
       (6).should.not.be.below(10, 'foo');
     }, "expected 6 to be above 10 | foo");
   },
-  
+
   'test match(regexp)': function(){
     'foobar'.should.match(/^foo/)
     'foobar'.should.not.match(/^bar/)
-    
+
     err(function(){
       'foobar'.should.match(/^bar/i)
     }, "expected 'foobar' to match /^bar/i");
-    
+
     err(function(){
       'foobar'.should.not.match(/^foo/i)
     }, "expected 'foobar' not to match /^foo/i");
@@ -203,21 +203,21 @@ module.exports = {
     err(function(){
       'foobar'.should.match(/^bar/i, 'foo')
     }, "expected 'foobar' to match /^bar/i | foo");
-    
+
     err(function(){
       'foobar'.should.not.match(/^foo/i, 'foo')
     }, "expected 'foobar' not to match /^foo/i | foo");
   },
-  
+
   'test length(n)': function(){
     'test'.should.have.length(4);
     'test'.should.not.have.length(3);
     [1,2,3].should.have.length(3);
-    
+
     err(function(){
       (4).should.have.length(3);
     }, 'expected 4 to have a property \'length\'');
-    
+
     err(function(){
       'asd'.should.not.have.length(3);
     }, "expected 'asd' to not have a length of 3");
@@ -225,19 +225,19 @@ module.exports = {
     err(function(){
       'asd'.should.have.length(4, 'foo');
     }, "expected 'asd' to have a length of 4 but got 3 | foo");
-    
+
     err(function(){
       'asd'.should.not.have.length(3, 'foo');
     }, "expected 'asd' to not have a length of 3 | foo");
 
   },
-  
+
   'test eql(val)': function(){
     'test'.should.eql('test');
     ({ foo: 'bar' }).should.eql({ foo: 'bar' });
     (1).should.eql(1);
     '4'.should.not.eql(4);
-    
+
     err(function(){
       (4).should.eql(3);
     }, 'expected 4 to equal 3');
@@ -272,11 +272,11 @@ module.exports = {
   'test equal(val)': function(){
     'test'.should.equal('test');
     (1).should.equal(1);
-    
+
     err(function(){
       (4).should.equal(3);
     }, 'expected 4 to equal 3');
-    
+
     err(function(){
       '4'.should.equal(4);
     }, "expected '4' to equal 4");
@@ -289,29 +289,29 @@ module.exports = {
       (4).should.not.equal(4, "foo");
     }, "expected 4 to not equal 4 | foo");
   },
-  
+
   'test empty': function(){
     ''.should.be.empty;
     [].should.be.empty;
     ({ length: 0 }).should.be.empty;
-    
+
     err(function(){
       ({}).should.be.empty;
     }, 'expected {} to have a property \'length\'');
-    
+
     err(function(){
       'asd'.should.be.empty;
     }, "expected 'asd' to be empty");
-    
+
     err(function(){
       ''.should.not.be.empty;
     }, "expected '' not to be empty");
   },
-  
+
   'test property(name)': function(){
     'test'.should.have.property('length');
     (4).should.not.have.property('length');
-    
+
     err(function(){
       'asd'.should.have.property('foo');
     }, "expected 'asd' to have a property 'foo'");
@@ -324,23 +324,23 @@ module.exports = {
       'asd'.should.not.have.property('length', undefined, 'foo');
     }, "expected 'asd' to not have a property 'length' | foo");
   },
-  
+
   'test property(name, val)': function(){
     'test'.should.have.property('length', 4);
     'asd'.should.have.property('constructor', String);
-    
+
     err(function(){
       'asd'.should.have.property('length', 4);
     }, "expected 'asd' to have a property 'length' of 4, but got 3");
-    
+
     err(function(){
       'asd'.should.not.have.property('length', 3);
     }, "expected 'asd' to not have a property 'length' of 3");
-    
+
     err(function(){
       'asd'.should.not.have.property('foo', 3);
     }, "'asd' has no property 'foo'");
-    
+
     err(function(){
       'asd'.should.have.property('constructor', Number);
     }, "expected 'asd' to have a property 'constructor' of [Function: Number], but got [Function: String]");
@@ -348,25 +348,25 @@ module.exports = {
     err(function(){
       'asd'.should.have.property('length', 4, 'foo');
     }, "expected 'asd' to have a property 'length' of 4, but got 3 | foo");
-    
+
     err(function(){
       'asd'.should.not.have.property('length', 3, 'foo');
     }, "expected 'asd' to not have a property 'length' of 3 | foo");
-    
+
     err(function(){
       'asd'.should.not.have.property('foo', 3, 'foo');
     }, "'asd' has no property 'foo' | foo");
-    
+
     err(function(){
       'asd'.should.have.property('constructor', Number, 'foo');
     }, "expected 'asd' to have a property 'constructor' of [Function: Number], but got [Function: String] | foo");
   },
-  
+
   'test ownProperty(name)': function(){
     'test'.should.have.ownProperty('length');
     'test'.should.haveOwnProperty('length');
     ({ length: 12 }).should.have.ownProperty('length');
-    
+
     err(function(){
       ({ length: 12 }).should.not.have.ownProperty('length');
     }, "expected { length: 12 } to not have own property 'length'");
@@ -384,11 +384,11 @@ module.exports = {
     'foobar'.should.include('bar');
     'foobar'.should.include('foo');
     'foobar'.should.not.include('baz');
-  
+
     err(function(){
       'foobar'.should.include('baz');
     }, "expected 'foobar' to include 'baz'");
-    
+
     err(function(){
       'foobar'.should.not.include('bar');
     }, "expected 'foobar' to not include 'bar'");
@@ -396,7 +396,7 @@ module.exports = {
     err(function(){
       'foobar'.should.include('baz', 'foo');
     }, "expected 'foobar' to include 'baz' | foo");
-    
+
     err(function(){
       'foobar'.should.not.include('bar', 'foo');
     }, "expected 'foobar' to not include 'bar' | foo");
@@ -413,7 +413,7 @@ module.exports = {
     err(function(){
       ['foo'].should.include('bar');
     }, "expected [ 'foo' ] to include 'bar'");
-    
+
     err(function(){
       ['bar', 'foo'].should.not.include('foo');
     }, "expected [ 'bar', 'foo' ] to not include 'foo'");
@@ -421,12 +421,12 @@ module.exports = {
     err(function(){
       ['foo'].should.include('bar', 'foo');
     }, "expected [ 'foo' ] to include 'bar' | foo");
-    
+
     err(function(){
       ['bar', 'foo'].should.not.include('foo', 'foo');
     }, "expected [ 'bar', 'foo' ] to not include 'foo' | foo");
   },
-  
+
   'test includeEql() with array': function(){
     [['foo'], ['bar']].should.includeEql(['foo']);
     [['foo'], ['bar']].should.includeEql(['bar']);
@@ -436,7 +436,7 @@ module.exports = {
     err(function(){
       [['foo']].should.includeEql(['bar']);
     }, "expected [ [ 'foo' ] ] to include an object equal to [ 'bar' ]");
-    
+
     err(function(){
       [['foo']].should.not.includeEql(['foo']);
     }, "expected [ [ 'foo' ] ] to not include an object equal to [ 'foo' ]");
@@ -444,12 +444,12 @@ module.exports = {
     err(function(){
       [['foo']].should.includeEql(['bar'], 'foo');
     }, "expected [ [ 'foo' ] ] to include an object equal to [ 'bar' ] | foo");
-    
+
     err(function(){
       [['foo']].should.not.includeEql(['foo'], 'foo');
     }, "expected [ [ 'foo' ] ] to not include an object equal to [ 'foo' ] | foo");
   },
-  
+
   'test keys(array)': function(){
     ({ foo: 1 }).should.have.keys(['foo']);
     ({ foo: 1, bar: 2 }).should.have.keys(['foo', 'bar']);
@@ -458,48 +458,48 @@ module.exports = {
     err(function(){
       ({ foo: 1 }).should.have.keys();
     }, "keys required");
-    
+
     err(function(){
       ({ foo: 1 }).should.have.keys([]);
     }, "keys required");
-    
+
     err(function(){
       ({ foo: 1 }).should.not.have.keys([]);
     }, "keys required");
-    
+
     err(function(){
       ({ foo: 1 }).should.have.keys(['bar']);
     }, "expected { foo: 1 } to have key 'bar'");
-    
+
     err(function(){
       ({ foo: 1 }).should.have.keys(['bar', 'baz']);
     }, "expected { foo: 1 } to have keys 'bar', and 'baz'");
-    
+
     err(function(){
       ({ foo: 1 }).should.have.keys(['foo', 'bar', 'baz']);
     }, "expected { foo: 1 } to have keys 'foo', 'bar', and 'baz'");
-  
+
     err(function(){
       ({ foo: 1 }).should.not.have.keys(['foo']);
     }, "expected { foo: 1 } to not have key 'foo'");
-    
+
     err(function(){
       ({ foo: 1 }).should.not.have.keys(['foo']);
     }, "expected { foo: 1 } to not have key 'foo'");
-    
+
     err(function(){
       ({ foo: 1, bar: 2 }).should.not.have.keys(['foo', 'bar']);
     }, "expected { foo: 1, bar: 2 } to not have keys 'foo', and 'bar'");
   },
-  
+
   'test chaining': function(){
     var user = { name: 'tj', pets: ['tobi', 'loki', 'jane', 'bandit'] };
     user.should.have.property('pets').with.lengthOf(4);
- 
+
     err(function(){
       user.should.have.property('pets').with.lengthOf(5);
     }, "expected [ 'tobi', 'loki', 'jane', 'bandit' ] to have a length of 5 but got 4");
- 
+
     user.should.be.a('object').and.have.property('name', 'tj');
   },
 
@@ -541,4 +541,4 @@ module.exports = {
       (function(){ throw new Error('error'); }).should.throw('fail');
     }, "expected an exception to be thrown with a message matching 'fail', but got 'error'");
   }
-}; 
+};

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -119,6 +119,19 @@ module.exports = {
     }, "expected 3 to be an instance of Foo | foo");
   },
 
+  'test instanceOf (non-reserved)': function(){
+    function Foo(){}
+    new Foo().should.be.an.instanceOf(Foo);
+
+    err(function(){
+      (9).should.an.instanceOf(Foo);
+    }, "expected 9 to be an instance of Foo");
+
+    err(function(){
+      (9).should.an.instanceOf(Foo, 'foo');
+    }, "expected 9 to be an instance of Foo | foo");
+  },
+
   'test within(start, finish)': function(){
     (5).should.be.within(5, 10);
     (5).should.be.within(3,6);


### PR DESCRIPTION
I've checked #47 and I totally agree with the fact that `.instanceof` is ok to be used even though it's a reserved keyword.

But it turns out that I have a particular example of when that fallback would help
1. Emacs running jshint

![http://f.cl.ly/items/040b2x1A3r060R1a011P/Screen%20Shot%202012-03-29%20at%2012.44.12%20AM.png](http://f.cl.ly/items/040b2x1A3r060R1a011P/Screen%20Shot%202012-03-29%20at%2012.44.12%20AM.png)
1. jshint output

![http://f.cl.ly/items/1c0N1s0V3M0i3G1R3i01/Screen%20Shot%202012-03-29%20at%2012.44.51%20AM.png](http://f.cl.ly/items/1c0N1s0V3M0i3G1R3i01/Screen%20Shot%202012-03-29%20at%2012.44.51%20AM.png)

As a side note, I'm sorry if the implementation is not optimal. I love javascript and I'm in the learning process, so I'm not very fluent yet. 

But at least I tried to add appropriate test coverage :)

Last but not least, I was also going to propose a change in package.json in order to support the conventional `npm test`, but when I tried that mocha did not produce any output. I was wondering what's the reason.

PS.: an honor to send a patch to you :raised_hands:
