### PR TITLE
Use valueOf(); fixes test cases on node v0.7.7

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -78,7 +78,7 @@ exports.not.exist = function(obj, msg){
 Object.defineProperty(Object.prototype, 'should', {
   set: function(){},
   get: function(){
-    return new Assertion(this);
+    return new Assertion(Object(this).valueOf());
   },
   configurable: true
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   , "contributors": [ "Aseem Kishore <aseem.kishore@gmail.com>" ]
   , "devDependencies": {
       "mocha": "*"
-    , "should": "*"
   }
   , "keywords": ["test", "bdd", "assert"]
   , "main": "./lib/should.js"

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -21,7 +21,7 @@ module.exports = {
   },
 
   'test double require': function(){
-    require('should').should.equal(should);
+    require('../').should.equal(should);
   },
 
   'test assertion': function(){


### PR DESCRIPTION
Hey TJ.

So Should.js broke on node v0.7.7 apparently. Tests were failing in a weird way. See the commit message of the first commit. Was easy enough to fix in a backwards-compatible way :)

Cheers!
