### PR TITLE
adding an alias for `throw`as `crash`, avoiding problems with jshint checks in strict mode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -296,7 +296,7 @@ Assert exepection message matches regexp:
 }).should.throw(/^fail/);
 ```
 
-## crash()
+## throwError()
 
 An alias of `throw`, its purpose is to be an option for those who run
 [jshint](https://github.com/jshint/node-jshint/) in strict mode.
@@ -304,7 +304,7 @@ An alias of `throw`, its purpose is to be an option for those who run
 ```js
 (function(){
   throw new Error('failed to baz');
-}).should.throw(/^fail.*/);
+}).should.throwError(/^fail.*/);
 ```
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 _should_ is an expressive, readable, test framework agnostic, assertion library for [node](http://nodejs.org).
-  
+
 It extends the Object prototype with a single non-enumerable getter that allows you to express how that object should behave.
 
 _should_ literally extends node's _assert_ module, in fact, it is node's assert module, for example `should.equal(str, 'foo')` will work, just as `assert.equal(str, 'foo')` would, and `should.AssertionError` **is** `assert.AssertionError`, meaning any test framework supporting this constructor will function properly with _should_.
@@ -13,7 +13,7 @@ _should_ literally extends node's _assert_ module, in fact, it is node's assert 
 
     user.should.have.property('name', 'tj');
     user.should.have.property('pets').with.lengthOf(4);
-    
+
     someAsyncTask(foo, function(err, result){
       should.not.exist(err);
       should.exist(result);
@@ -161,12 +161,12 @@ Assert __typeof__:
     user.should.be.a('object')
     'test'.should.be.a('string')
 
-## instanceof
+## instanceof and instanceOf
 
-Assert __instanceof__:
+Assert __instanceof__ or __instanceOf__:
 
     user.should.be.an.instanceof(User)
-    [].should.be.an.instanceof(Array)
+    [].should.be.an.instanceOf(Array)
 
 ## above
 
@@ -229,13 +229,13 @@ Assert own property (on the immediate object):
 ## json
 
   Assert that Content-Type is "application/json; charset=utf-8"
-  
+
       res.should.be.json
 
 ## html
 
   Assert that Content-Type is "text/html; charset=utf-8"
-  
+
       res.should.be.html
 
 ## include(obj)
@@ -277,7 +277,7 @@ Assert an exception is not thrown:
 
 ```js
 (function(){
- 
+
 }).should.not.throw();
 ```
 Assert exepection message matches string:
@@ -295,6 +295,18 @@ Assert exepection message matches regexp:
   throw new Error('failed to foo');
 }).should.throw(/^fail/);
 ```
+
+## crash()
+
+An alias of `throw`, its purpose is to be an option for those who run
+[jshint](https://github.com/jshint/node-jshint/) in strict mode.
+
+```js
+(function(){
+  throw new Error('failed to baz');
+}).should.throw(/^fail.*/);
+```
+
 
 ## keys
 
@@ -323,7 +335,7 @@ For example you can use should with the [Expresso TDD Framework](http://github.c
 
     var lib = require('mylib')
       , should = require('should');
-  
+
     module.exports = {
       'test .version': function(){
         lib.version.should.match(/^\d+\.\d+\.\d+$/);
@@ -340,7 +352,7 @@ To run the tests for _should_ simply update your git submodules and run:
 
 Yes, yes it does, with a single getter _should_, and no it won't break your code, because it does this **properly** with a non-enumerable property.
 
-## License 
+## License
 
 (The MIT License)
 

--- a/lib/should.js
+++ b/lib/should.js
@@ -686,7 +686,7 @@ Assertion.prototype = {
 };
 
 Assertion.prototype.instanceOf = Assertion.prototype.instanceof;
-Assertion.prototype.crash = Assertion.prototype.throw;
+Assertion.prototype.throwError = Assertion.prototype.throw;
 
 /**
  * Aliases.

--- a/lib/should.js
+++ b/lib/should.js
@@ -684,7 +684,10 @@ Assertion.prototype = {
     return this;
   }
 };
+
 Assertion.prototype.instanceOf = Assertion.prototype.instanceof;
+Assertion.prototype.crash = Assertion.prototype.throw;
+
 /**
  * Aliases.
  */

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -555,42 +555,42 @@ module.exports = {
     }, "expected an exception to be thrown with a message matching 'fail', but got 'error'");
   },
 
-  'test crash()': function(){
-    (function(){}).should.not.crash();
-    (function(){ throw new Error('fail') }).should.crash();
+  'test throwError()': function(){
+    (function(){}).should.not.throwError();
+    (function(){ throw new Error('fail') }).should.throwError();
 
     err(function(){
-      (function(){}).should.crash();
+      (function(){}).should.throwError();
     }, 'expected an exception to be thrown');
 
     err(function(){
       (function(){
         throw new Error('fail');
-      }).should.not.crash();
+      }).should.not.throwError();
     }, 'expected no exception to be thrown, got "fail"');
   },
 
-  'test crash() with regex message': function(){
-    (function(){ throw new Error('fail'); }).should.crash(/fail/);
+  'test throwError() with regex message': function(){
+    (function(){ throw new Error('fail'); }).should.throwError(/fail/);
 
     err(function(){
-      (function(){}).should.crash(/fail/);
+      (function(){}).should.throwError(/fail/);
     }, 'expected an exception to be thrown');
 
     err(function(){
-      (function(){ throw new Error('error'); }).should.crash(/fail/);
+      (function(){ throw new Error('error'); }).should.throwError(/fail/);
     }, "expected an exception to be thrown with a message matching /fail/, but got 'error'");
   },
 
-  'test crash() with string message': function(){
-    (function(){ throw new Error('fail'); }).should.crash('fail');
+  'test throwError() with string message': function(){
+    (function(){ throw new Error('fail'); }).should.throwError('fail');
 
     err(function(){
-      (function(){}).should.crash('fail');
+      (function(){}).should.throwError('fail');
     }, 'expected an exception to be thrown');
 
     err(function(){
-      (function(){ throw new Error('error'); }).should.crash('fail');
+      (function(){ throw new Error('error'); }).should.throwError('fail');
     }, "expected an exception to be thrown with a message matching 'fail', but got 'error'");
   }
 

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -553,5 +553,45 @@ module.exports = {
     err(function(){
       (function(){ throw new Error('error'); }).should.throw('fail');
     }, "expected an exception to be thrown with a message matching 'fail', but got 'error'");
+  },
+
+  'test crash()': function(){
+    (function(){}).should.not.crash();
+    (function(){ throw new Error('fail') }).should.crash();
+
+    err(function(){
+      (function(){}).should.crash();
+    }, 'expected an exception to be thrown');
+
+    err(function(){
+      (function(){
+        throw new Error('fail');
+      }).should.not.crash();
+    }, 'expected no exception to be thrown, got "fail"');
+  },
+
+  'test crash() with regex message': function(){
+    (function(){ throw new Error('fail'); }).should.crash(/fail/);
+
+    err(function(){
+      (function(){}).should.crash(/fail/);
+    }, 'expected an exception to be thrown');
+
+    err(function(){
+      (function(){ throw new Error('error'); }).should.crash(/fail/);
+    }, "expected an exception to be thrown with a message matching /fail/, but got 'error'");
+  },
+
+  'test crash() with string message': function(){
+    (function(){ throw new Error('fail'); }).should.crash('fail');
+
+    err(function(){
+      (function(){}).should.crash('fail');
+    }, 'expected an exception to be thrown');
+
+    err(function(){
+      (function(){ throw new Error('error'); }).should.crash('fail');
+    }, "expected an exception to be thrown with a message matching 'fail', but got 'error'");
   }
+
 };


### PR DESCRIPTION
Hello TJ,

this commit has the exact same purpose of the previous one I sent.

That avoids emacs with jshint to complain about it:

![http://f.cl.ly/items/2k3w1N3A033c0M3q3N0I/Screen%20Shot%202012-04-01%20at%201.45.12%20AM.png](http://f.cl.ly/items/2k3w1N3A033c0M3q3N0I/Screen%20Shot%202012-04-01%20at%201.45.12%20AM.png)

I also added a small example of usage in the readme and update it regarding `instanceOf`
