### PR TITLE
Introduce assertions for each type as in Vows

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -357,7 +357,45 @@ Assertion.prototype = {
       , 'expected ' + this.inspect + ' not to be an instance of ' + name + (desc ? " | " + desc : ""));
     return this;
   },
-
+  get Function(){
+    this.assert(
+      typeof this.obj === "function" || this.obj instanceof Function
+      , 'expected ' + this.inspect + ' to be a function'
+      , 'expected ' + this.inspect + ' not to be a function');
+    return this;
+  },
+  get Object(){
+    this.assert(
+      typeof this.obj === "object" && this.obj && !Array.isArray(this.obj)
+      , 'expected ' + this.inspect + ' to be an object'
+      , 'expected ' + this.inspect + ' not to be an object');
+    return this;
+  },
+  get String(){
+    this.assert(
+      typeof this.obj === "string" && this.obj instanceof String
+      , 'expected ' + this.inspect + ' to be a string'
+      , 'expected ' + this.inspect + ' not to be a string');
+    return this;
+  },
+  get Array(){
+    this.assert(
+      Array.isArray(this.obj)
+      , 'expected ' + this.inspect + ' to be an array'
+      , 'expected ' + this.inspect + ' not to be an array');
+  },
+  get Number(){
+    this.assert(
+      !isNaN(this.obj) && typeof this.obj === "number"
+      , 'expected ' + this.inspect + ' to be a number'
+      , 'expected ' + this.inspect + ' not to be a number');
+  },
+  get Boolean(){
+    this.assert(
+      typeof this.obj === "boolean"
+      , 'expected ' + this.inspect + ' to be a boolean'
+      , 'expected ' + this.inspect + ' not to be a boolean');
+  },
   /**
    * Assert numeric value above _n_.
    *


### PR DESCRIPTION
Allows you to do things like:

``` javascript
var val = [1,2,3];
val.should.be.an.Array;

val = 10;
val.should.be.a.Number;
```
