### PR TITLE
Square brackets around optional parameters in JSDoc tags

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -38,7 +38,7 @@ exports.version = '0.6.1';
  * Assert _obj_ exists, with optional message.
  *
  * @param {Mixed} obj
- * @param {String} msg
+ * @param {String} [msg]
  * @api public
  */
 
@@ -55,7 +55,7 @@ exports.exist = function(obj, msg){
  * Asserts _obj_ does not exist, with optional message.
  *
  * @param {Mixed} obj
- * @param {String} msg
+ * @param {String} [msg]
  * @api public
  */
 
@@ -428,7 +428,7 @@ Assertion.prototype = {
    * Assert property _name_ exists, with optional _val_.
    *
    * @param {String} name
-   * @param {Mixed} val
+   * @param {Mixed} [val]
    * @param {String} description
    * @api public
    */


### PR DESCRIPTION
Useful for IDEs and compilers that can inspect JSDoc tags.
