### PR TITLE
fix 'test .expected and .actual'

### DIFF
--- a/test/should.test.js
+++ b/test/should.test.js
@@ -68,8 +68,8 @@ module.exports = {
     try {
       'foo'.should.equal('bar');
     } catch (err) {
-      assert('foo' == err.actual, 'err.actual');
-      assert('bar' == err.expected, 'err.expected');
+      'foo'.should.equal(err.actual, 'err.actual');
+      'bar'.should.equal(err.expected, 'err.expected');
     }
   },
 


### PR DESCRIPTION
when I run `make test` this test failed with this error:

✖ 1 of 46 tests failed:

  1)  test .expected and .actual:
     TypeError: object is not a function
      at Object.CALL_NON_FUNCTION (native)
      at Context.<anonymous> (/Users/raf/projects/js/should.js/test/should.test.js:71:20)
      at Test.run (/Users/raf/projects/js/should.js/node_modules/mocha/lib/runnable.js:158:32)
      at Runner.runTest (/Users/raf/projects/js/should.js/node_modules/mocha/lib/runner.js:292:10)
      at /Users/raf/projects/js/should.js/node_modules/mocha/lib/runner.js:336:12
      at next (/Users/raf/projects/js/should.js/node_modules/mocha/lib/runner.js:220:14)
      at /Users/raf/projects/js/should.js/node_modules/mocha/lib/runner.js:229:7
      at next (/Users/raf/projects/js/should.js/node_modules/mocha/lib/runner.js:179:23)
      at Array.<anonymous> (/Users/raf/projects/js/should.js/node_modules/mocha/lib/runner.js:197:5)
      at EventEmitter._tickCallback (node.js:126:26)

not sure why you were using `assert` there though.

After the fix:

.............................................

✔ 45 tests complete (46ms)
