### PR TITLE
Use .valueOf() only when necessary.

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -79,7 +79,11 @@ exports.not.exist = function(obj, msg){
 Object.defineProperty(Object.prototype, 'should', {
   set: function(){},
   get: function(){
-    return new Assertion(Object(this).valueOf());
+    if ('object' == typeof this && [Boolean, Number, String].indexOf(this.constructor) != -1) {
+      return new Assertion(this.valueOf());
+    } else {
+      return new Assertion(this);
+    }
   },
   configurable: true
 });
@@ -301,7 +305,7 @@ Assertion.prototype = {
 
   equal: function(val, desc){
     this.assert(
-        val.valueOf() === this.obj
+        val === this.obj
       , 'expected ' + this.inspect + ' to equal ' + i(val) + (desc ? " | " + desc : "")
       , 'expected ' + this.inspect + ' to not equal ' + i(val) + (desc ? " | " + desc : "")
       , val);

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -117,6 +117,8 @@ module.exports = {
     err(function(){
       (3).should.an.instanceof(Foo, 'foo');
     }, "expected 3 to be an instance of Foo | foo");
+
+    (new Date).should.be.an.instanceof(Date);
   },
 
   'test instanceOf (non-reserved)': function(){


### PR DESCRIPTION
Recent versions of V8 (node 0.7.6+) cause a fairly-transparent Object
wrapper to be applied to primitives when they're used as an Object
instance.

This hack detects these wrappers -- possibly incompletely -- and unwraps
the it in these instances, for equality tests' sakes.

See #65.
