### PR TITLE
Added floating point numbers test support

### DIFF
--- a/lib/eql.js
+++ b/lib/eql.js
@@ -4,9 +4,9 @@
 
 module.exports = _deepEqual;
 
-function _deepEqual(actual, expected) {
+function _deepEqual(actual, expected, delta) {
   // 7.1. All identical values are equivalent, as determined by ===.
-  if (actual === expected) {
+  if (actual === expected || (!isUndefinedOrNull(delta) && Math.abs(actual - expected) <= delta)) {
     return true;
 
   } else if (Buffer.isBuffer(actual) && Buffer.isBuffer(expected)) {
@@ -35,7 +35,7 @@ function _deepEqual(actual, expected) {
   // corresponding key, and an identical "prototype" property. Note: this
   // accounts for both named and indexed properties on Arrays.
   } else {
-    return objEquiv(actual, expected);
+    return objEquiv(actual, expected, delta);
   }
 }
 
@@ -47,7 +47,7 @@ function isArguments (object) {
   return Object.prototype.toString.call(object) == '[object Arguments]';
 }
 
-function objEquiv (a, b) {
+function objEquiv (a, b, delta) {
   if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
     return false;
   // an identical "prototype" property.
@@ -60,7 +60,7 @@ function objEquiv (a, b) {
     }
     a = pSlice.call(a);
     b = pSlice.call(b);
-    return _deepEqual(a, b);
+    return _deepEqual(a, b, delta);
   }
   try{
     var ka = Object.keys(a),
@@ -80,11 +80,12 @@ function objEquiv (a, b) {
     if (ka[i] != kb[i])
       return false;
   }
+  
   //equivalent values for every corresponding key, and
   //~~~possibly expensive deep test
   for (i = ka.length - 1; i >= 0; i--) {
     key = ka[i];
-    if (!_deepEqual(a[key], b[key] ))
+    if (!_deepEqual(a[key], b[key], delta ))
        return false;
   }
   return true;

--- a/lib/should.js
+++ b/lib/should.js
@@ -292,6 +292,23 @@ Assertion.prototype = {
   },
 
   /**
+   * Assert equal for floating point numbers
+   *
+   * @param {Number} val
+   * @param {Number} eps
+   * @param {String} description
+   * @api public
+   */
+  feql: function(val, delta, desc){
+    this.assert(
+        eql(val, this.obj, delta)
+      , 'expected ' + this.inspect + ' to equal ' + i(val) + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not equal ' + i(val) + (desc ? " | " + desc : "")
+      , val);
+    return this;
+  },
+
+  /**
    * Assert strict equal.
    *
    * @param {Mixed} val


### PR DESCRIPTION
I added a test function for floating point numbers, feql(), to should.js. The function takes the expected value, the actual value and a delta used to check the maximum difference between the two floating point numbers

feql(10.1, 10.2, 0.2) => true
feql(10.1, 10.2, 0.1) => false
