### PR TITLE
Allow for providing arguments directly to throw

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -307,6 +307,25 @@ Assert exepection message matches regexp:
 }).should.throw(/^fail/);
 ```
 
+Assert exepection with function arguments (note: requires a string or regex match)
+
+```js
+(function(a){
+  if(a === 1){
+    throw new Error('failed to foo');
+  }
+}).should.throw(1, /^fail/);
+```
+
+Assert exepection with function arguments when you don't care about what error was thrown
+```js
+(function(a){
+  if(a === 1){
+    throw new Error('any old error');
+  }
+}).should.throw(1, null);
+```
+
 ## throwError()
 
 An alias of `throw`, its purpose is to be an option for those who run

--- a/lib/should.js
+++ b/lib/should.js
@@ -652,18 +652,22 @@ Assertion.prototype = {
    * Assert that this function will or will not
    * throw an exception.
    *
+   * @param args {...*} the arguments to pass to the function for assertion
+   * @param message {RegExp|string} a RegExp for testing the error message against or the assertion message
    * @return {Assertion} for chaining
    * @api public
    */
 
-  throw: function(message){
+  throw: function(/* args..., message */){
     var fn = this.obj
+      , args = Array.prototype.slice.call(arguments, 0)
+      , message = args.pop()
       , err = {}
       , errorInfo = ''
       , ok = true;
 
     try {
-      fn();
+      fn.apply(this, args);
       ok = false;
     } catch (e) {
       err = e;

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -575,6 +575,27 @@ module.exports = {
     }, "expected an exception to be thrown with a message matching 'fail', but got 'error'");
   },
 
+  'test throw() with optional arguments': function(){
+
+    var throwsOn1 = function(a){
+      if( a === 1 ){
+        throw new Error('fail');
+      }
+    };
+
+    throwsOn1.should.throw(1, 'fail');
+    throwsOn1.should.not.throw(2, 'fail');
+
+    // testing for the null last parameter case
+    throwsOn1.should.throw(1, null);
+    throwsOn1.should.not.throw(2, null);
+
+    err(function(){
+      throwsOn1.should.throw(2, 'fail');
+    }, 'expected an exception to be thrown');
+
+  },
+
   'test throwError()': function(){
     (function(){}).should.not.throwError();
     (function(){ throw new Error('fail') }).should.throwError();


### PR DESCRIPTION
This is very helpful for  testing functions which can throw different types of errors, or which should conditionally throw

``` js
var throwsSometimes = function(a){
  if( a === 1 ){
    throw new Error('invalid argument');
  }
};

throwsSometimes.should.throw(1, /^invalid/);
throwsSometimes.should.not.throw(50, /^invalid/);
```
