### PR TITLE
Check the type of a thrown exception with should.throw().

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -674,13 +674,17 @@ Assertion.prototype = {
         ok = message == err.message;
       } else if (message instanceof RegExp) {
         ok = message.test(err.message);
+      } else if ('function' == typeof message) {
+        ok = err instanceof message;
       }
 
       if (message && !ok) {
         if ('string' == typeof message) {
           errorInfo = " with a message matching '" + message + "', but got '" + err.message + "'";
-        } else {
+        } else if (message instanceof RegExp) {
           errorInfo = " with a message matching " + message + ", but got '" + err.message + "'";
+        } else if ('function' == typeof message) {
+          errorInfo = " of type " + message.name + ", but got " + err.constructor.name;
         }
       }
     }

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -575,6 +575,18 @@ module.exports = {
     }, "expected an exception to be thrown with a message matching 'fail', but got 'error'");
   },
 
+  'test throw() with type': function(){
+    (function(){ throw new Error('fail'); }).should.throw(Error);
+
+    err(function(){
+      (function(){}).should.throw(Error);
+    }, 'expected an exception to be thrown');
+
+    err(function(){
+      (function(){ throw 'error'; }).should.throw(Error);
+    }, "expected an exception to be thrown of type Error, but got String");
+  },
+
   'test throwError()': function(){
     (function(){}).should.not.throwError();
     (function(){ throw new Error('fail') }).should.throwError();
@@ -612,6 +624,18 @@ module.exports = {
     err(function(){
       (function(){ throw new Error('error'); }).should.throwError('fail');
     }, "expected an exception to be thrown with a message matching 'fail', but got 'error'");
+  },
+
+  'test throwError() with type': function(){
+    (function(){ throw new Error('fail'); }).should.throw(Error);
+
+    err(function(){
+      (function(){}).should.throw(Error);
+    }, 'expected an exception to be thrown');
+
+    err(function(){
+      (function(){ throw 'error'; }).should.throw(Error);
+    }, "expected an exception to be thrown of type Error, but got String");
   }
 
 };


### PR DESCRIPTION
This patch allows you to specify a constructor to should.throw to test that the function throws an exception of the given type. Something like:

```
func.should.throw(SomeError);
```
