### PR TITLE
repurposed contain method to search within a string

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -516,19 +516,20 @@ Assertion.prototype = {
   },
 
   /**
-   * Assert that the array contains _obj_.
+   * Assert that the string contains _str_.
    *
-   * @param {Mixed} obj
+   * @param {String} str
+   * @param {String} description
    * @api public
    */
 
-  contain: function(obj){
-    console.warn('should.contain() is deprecated, use should.include()');
-    this.obj.should.be.an.instanceof(Array);
+  contain: function(str, desc){
+    this.obj.should.be.a('string');
+    var search = this.obj.search(str);
     this.assert(
-        ~this.obj.indexOf(obj)
-      , 'expected ' + this.inspect + ' to contain ' + i(obj)
-      , 'expected ' + this.inspect + ' to not contain ' + i(obj));
+        search != -1
+      , 'expected ' + this.inspect + ' to contain ' + str + (desc ? " | " + desc : "")
+      , 'expected ' + this.inspect + ' to not contain ' + str + (desc ? " | " + desc : ""));
     return this;
   },
 


### PR DESCRIPTION
Considering the contain method is becoming deprecated I have repurposed it to act as a string searching method. This has been very useful for me when I search through various error messages on my browser via zombie.js

eg. usage: var str = 'a string';
str.should.contain('string')       // passes
str.should.contain('String')      // fails
