### PR TITLE
Update lib/should.js

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -1,4 +1,3 @@
-
 /*!
  * Should
  * Copyright(c) 2010-2012 TJ Holowaychuk <tj@vision-media.ca>
@@ -43,7 +42,7 @@ exports.version = '1.0.0';
  * @api public
  */
 
-exports.exist = function(obj, msg){
+exports.exist = exports.exists = function(obj, msg){
   if (null == obj) {
     throw new AssertionError({
         message: msg || ('expected ' + i(obj) + ' to exist')
@@ -61,7 +60,7 @@ exports.exist = function(obj, msg){
  */
 
 exports.not = {};
-exports.not.exist = function(obj, msg){
+exports.not.exist = exports.not.exists = function(obj, msg){
   if (null != obj) {
     throw new AssertionError({
         message: msg || ('expected ' + i(obj) + ' to not exist')


### PR DESCRIPTION
alias exists for exist

`shoul.not.exists(err)` is a common error when use should.
