### PR TITLE
Added #approximately(value, delta, desc) for comparison of numbers within given precision

### DIFF
--- a/examples/runner.js
+++ b/examples/runner.js
@@ -50,4 +50,16 @@ test('Point#add()', function(){
   point.should.respondTo('add');
 });
 
+test('Math#sin()', function(){
+  Math.sin(12).should.be.approximately(-0.5365, 1e-3);
+});
+
+test('Math#cos()', function(){
+  Math.cos(0).should.not.be.approximately(10, 1e-3);
+});
+
+test('Math#log()', function(){
+  Math.log(10).should.be.approximately(10, 1e-3);
+});
+
 console.log();

--- a/lib/should.js
+++ b/lib/should.js
@@ -322,6 +322,19 @@ Assertion.prototype = {
   },
 
   /**
+   * Assert within value +- delta (inclusive).
+   *
+   * @param {Number} value
+   * @param {Number} delta
+   * @param {String} description
+   * @api public
+   */
+
+  approximately: function(value, delta, description) {
+    return this.within(value - delta, value + delta, description);
+  },
+
+  /**
    * Assert typeof.
    *
    * @param {Mixed} type


### PR DESCRIPTION
It's quite handy to have something like this:

(3/4*Math.cos(0)).should.be.approximately(0.75, 1e-2);

But at the moment I haven't found such possibility in should.js. So, since I like this library and don't want to switch to another one, please, accept these changes and merge them into master to be released (I hope) soon.
