### PR TITLE
Fix should[.not].exist not having stack trace #84

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -40,7 +40,7 @@ exports.exist = exports.exists = function(obj, msg){
   if (null == obj) {
     throw new AssertionError({
         message: msg || ('expected ' + i(obj) + ' to exist')
-      , stackStartFunction: should.exist
+      , stackStartFunction: exports.exist
     });
   }
 };
@@ -58,7 +58,7 @@ exports.not.exist = exports.not.exists = function(obj, msg){
   if (null != obj) {
     throw new AssertionError({
         message: msg || ('expected ' + i(obj) + ' to not exist')
-      , stackStartFunction: should.not.exist
+      , stackStartFunction: exports.not.exist
     });
   }
 };

--- a/test/exist.test.js
+++ b/test/exist.test.js
@@ -12,6 +12,12 @@ function err(fn, msg) {
     should.fail('expected an error');
   } catch (err) {
     should.equal(msg, err.message);
+    should(err.stack, 'Expected error to have an stack trace');
+
+    var stackTraceFirstLine = err.stack.split('\n')[1];
+    var message = 'Expected error to have a proper stack trace showing the file names';
+    should(stackTraceFirstLine, message); 
+    stackTraceFirstLine.should.match(/at\s*[\S]+/, message);
   }
 }
 


### PR DESCRIPTION
This was because should wasn't defined in that context and was referring
to should property of the `global` object which is from the prototype.
So `should.exist` and `should.not.exist` were undefined, which made
stackStartFunction properties in those functions undefined.
