### PR TITLE
bugfix - pSlice used, but not defined in eql.js

### DIFF
--- a/lib/eql.js
+++ b/lib/eql.js
@@ -4,6 +4,8 @@
 
 module.exports = _deepEqual;
 
+var pSlice = Array.prototype.slice;
+
 function _deepEqual(actual, expected) {
   // 7.1. All identical values are equivalent, as determined by ===.
   if (actual === expected) {

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -246,6 +246,13 @@ module.exports = {
     ({ foo: 'bar' }).should.eql({ foo: 'bar' });
     (1).should.eql(1);
     '4'.should.not.eql(4);
+    var memo = [];
+    function memorize() {
+        memo.push(arguments);
+    }
+    memorize('a', [1, 2]);
+    memorize('a', [1, 2]);
+    memo[0].should.eql(memo[1]);
 
     err(function(){
       (4).should.eql(3);


### PR DESCRIPTION
fix missing reference to pSlice in eql.js & include a unit test to verify...

unit test prior to eql.js change

```
  ✖ 1 of 52 tests failed:

  1)  test eql(val):
     ReferenceError: pSlice is not defined
      at objEquiv (/home/boden/git/should.js/lib/eql.js:61:9)
      at _deepEqual (/home/boden/git/should.js/lib/eql.js:38:12)
      at Object.Assertion.eql (/home/boden/git/should.js/lib/should.js:286:9)
      at Context.module.exports.test eql(val) (/home/boden/git/should.js/test/should.test.js:255:20)
      at Test.Runnable.run (/home/boden/git/should.js/node_modules/mocha/lib/runnable.js:213:32)
      at Runner.runTest (/home/boden/git/should.js/node_modules/mocha/lib/runner.js:343:10)
      at Runner.runTests.next (/home/boden/git/should.js/node_modules/mocha/lib/runner.js:389:12)
      at next (/home/boden/git/should.js/node_modules/mocha/lib/runner.js:269:14)
      at Runner.hooks (/home/boden/git/should.js/node_modules/mocha/lib/runner.js:278:7)
      at next (/home/boden/git/should.js/node_modules/mocha/lib/runner.js:226:23)
      at Runner.hook (/home/boden/git/should.js/node_modules/mocha/lib/runner.js:246:5)
      at process.startup.processNextTick.process._tickCallback (node.js:244:9)


make: *** [test] Error 1
```

after change:

```
52 tests complete (16 ms)
```
