### PR TITLE
max, min, email and url

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -168,6 +168,21 @@ Assert __instanceof__ or __instanceOf__:
     user.should.be.an.instanceof(User)
     [].should.be.an.instanceOf(Array)
 
+## min
+
+Assert numeric value above or equal the given value:
+
+    user.age.should.be.min(5)
+    user.age.should.not.be.min(100)
+
+## max
+
+Assert numeric value bellow or equal the given value:
+
+    user.age.should.be.max(5)
+    user.age.should.not.be.max(100)
+
+
 ## above
 
 Assert numeric value above the given value:
@@ -181,6 +196,19 @@ Assert numeric value below the given value:
 
     user.age.should.be.below(100)
     user.age.should.not.be.below(5)
+
+## email
+
+Assert string is a valid email RFC 822 address:
+
+    emailAddr.should.be.an.email()
+
+## url
+
+Assert string is a valid url:
+
+    link.should.be.a.url()
+
 
 ## match
 

--- a/lib/should.js
+++ b/lib/should.js
@@ -272,7 +272,7 @@ Assertion.prototype = {
       , function(){ return 'expected ' + this.inspect + ' not to be false' });
     return this;
   },
-
+  
   /**
    * Assert equal.
    *
@@ -351,7 +351,7 @@ Assertion.prototype = {
     this.assert(
         type == typeof this.obj
       , function(){ return 'expected ' + this.inspect + ' to be a ' + type + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' not to be a ' + type  + (desc ? " | " + desc : "") })
+      , function(){ return 'expected ' + this.inspect + ' not to be a ' + type  + (desc ? " | " + desc : "") }) 
     return this;
   },
 
@@ -371,6 +371,38 @@ Assertion.prototype = {
       , function(){ return 'expected ' + this.inspect + ' not to be an instance of ' + name + (desc ? " | " + desc : "") });
     return this;
   },
+  
+  /**
+   * Assert numeric value at or bellow _n_.
+   *
+   * @param {Number} n
+   * @param {String} description
+   * @api public
+   */
+
+  max: function(n, desc){
+    this.assert(
+        this.obj <= n
+      , function(){ return 'expected ' + this.inspect + ' to be bellow or equal ' + n + (desc ? " | " + desc : "") }
+      , function(){ return 'expected ' + this.inspect + ' to be above or equal ' + n + (desc ? " | " + desc : "") });
+    return this;
+  },
+  
+  /**
+   * Assert numeric value at or above _n_.
+   *
+   * @param {Number} n
+   * @param {String} description
+   * @api public
+   */
+
+  min: function(n, desc){
+    this.assert(
+        this.obj >= n
+      , function(){ return 'expected ' + this.inspect + ' to be above or equal ' + n + (desc ? " | " + desc : "") }
+      , function(){ return 'expected ' + this.inspect + ' to be below or equal ' + n + (desc ? " | " + desc : "") });
+    return this;
+  },
 
   /**
    * Assert numeric value above _n_.
@@ -387,7 +419,7 @@ Assertion.prototype = {
       , function(){ return 'expected ' + this.inspect + ' to be below ' + n + (desc ? " | " + desc : "") });
     return this;
   },
-
+  
   /**
    * Assert numeric value below _n_.
    *
@@ -419,7 +451,55 @@ Assertion.prototype = {
       , function(){ return 'expected ' + this.inspect + ' not to match ' + regexp + (desc ? " | " + desc : "") });
     return this;
   },
-
+  
+  /**
+   * Assert is URL
+   * 
+   * @param {String} val
+   * @param {String} description
+   * @api public
+   */
+  url : function(desc) {
+    var urlRe = /^(?:(?:ht|f)tp(?:s?)\:\/\/|~\/|\/)?(?:\w+:\w+@)?(localhost|(?:(?:[-\w\d{1-3}]+\.)+(?:com|org|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,="'\(\)_\*:]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |\/.,*:;=]|%[a-f\d]{2})*)?$/i;
+    this.assert(
+        urlRe.exec(this.obj)
+      , function(){ return 'expected ' + this.inspect + ' to be a valid URL ' + (desc ? " | " + desc : "") }
+      , function(){ return 'expected ' + this.inspect + ' not to be a valid URL ' + (desc ? " | " + desc : "") });
+    return this;
+  },
+  
+  /**
+   * Assert is email
+   * 
+   * @param {String} val
+   * @param {String} description
+   * @api public
+   *
+   * Based on regex from http://iamcal.com/publish/articles/php/parsing_email/
+   */
+  
+  email : function(desc) {
+    var qtext = '[^\\x0d\\x22\\x5c\\x80-\\xff]';
+    var dtext = '[^\\x0d\\x5b-\\x5d\\x80-\\xff]';
+    var atom = '[^\\x00-\\x20\\x22\\x28\\x29\\x2c\\x2e\\x3a-\\x3c' +
+               '\\x3e\\x40\\x5b-\\x5d\\x7f-\\xff]+';
+    var quoted_pair = '\\x5c[\\x00-\\x7f]';
+    var domain_literal = "\\x5b(" + dtext + "|" + quoted_pair + ")*\\x5d";
+    var quoted_string = "\\x22(" + qtext + "|" + quoted_pair + ")*\\x22";
+    var domain_ref = atom;
+    var sub_domain = "(" + domain_ref + "|" + domain_literal +")";
+    var word = "(" + atom + "|" + quoted_string + ")";
+    var domain = sub_domain + "(\\x2e" + sub_domain +")*";
+    var local_part = word + "(\\x2e" + word + ")*";
+    var addr_spec = local_part + "\\x40"+ domain;
+    var emailRe = new RegExp("^"+ addr_spec + "$");
+    this.assert(
+        emailRe.exec(this.obj)
+      , function(){ return 'expected ' + this.inspect + ' to be an email ' + (desc ? " | " + desc : "") }
+      , function(){ return 'expected ' + this.inspect + ' not to be and email ' + (desc ? " | " + desc : "") });
+    return this;
+  },
+  
   /**
    * Assert property "length" exists and has value of _n_.
    *
@@ -484,7 +564,6 @@ Assertion.prototype = {
         this.obj.hasOwnProperty(name)
       , function(){ return 'expected ' + this.inspect + ' to have own property ' + i(name) + (desc ? " | " + desc : "") }
       , function(){ return 'expected ' + this.inspect + ' to not have own property ' + i(name) + (desc ? " | " + desc : "") });
-    this.obj = this.obj[name];
     return this;
   },
 


### PR DESCRIPTION
Hi I added validators for min, max, email and url
min (>=) and max (<=) work like above and bellow, but are inclusive of the given number.

email test for RFC822 address
url tests for valid URLs

hope you can merge these back in.
