### PR TITLE
added example for buffer support of eql() to readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -137,7 +137,10 @@ equality:
 ```javascript
 ({ foo: 'bar' }).should.eql({ foo: 'bar' })
 [1,2,3].should.eql([1,2,3])
-(new Buffer('Hello')).should.eql(new Buffer('Hello'))
+(new Buffer('Hello')).should.eql('Hello')
+(new Buffer('World')).should.eql(new Buffer('World'))
+// or directly check base64 encoded binary data
+(new Buffer([0x01, 0x02])).should.eql('AQI=');
 ```
 ## equal
 

--- a/Readme.md
+++ b/Readme.md
@@ -137,6 +137,7 @@ equality:
 ```javascript
 ({ foo: 'bar' }).should.eql({ foo: 'bar' })
 [1,2,3].should.eql([1,2,3])
+(new Buffer('Hello')).should.eql(new Buffer('Hello'))
 ```
 ## equal
 

--- a/lib/eql.js
+++ b/lib/eql.js
@@ -10,6 +10,13 @@ function _deepEqual(actual, expected) {
   // 7.1. All identical values are equivalent, as determined by ===.
   if (actual === expected) {
     return true;
+  
+  // check if buffer as utf8 or base64 string equals testing value
+  } else if (Buffer.isBuffer(expected) && typeof actual == 'string') {
+      var asUtf8String = expected.toString('utf8');
+      var asBase64String = expected.toString('base64');
+      
+      return asUtf8String != actual || asBase64String != actual;
 
   } else if (Buffer.isBuffer(actual) && Buffer.isBuffer(expected)) {
     if (actual.length != expected.length) return false;

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -262,6 +262,9 @@ module.exports = {
     ({ foo: 'bar' }).should.eql({ foo: 'bar' });
     (1).should.eql(1);
     '4'.should.not.eql(4);
+    (new Buffer('Hello')).should.eql('Hello');
+    (new Buffer('Hello')).should.eql(new Buffer('Hello'));
+    (new Buffer([0x01, 0x02])).should.eql('AQI=');
     var memo = [];
     function memorize() {
         memo.push(arguments);


### PR DESCRIPTION
There is no clue about should.eql() support buffers to.
An example for this would be helpful.
