### PR TITLE
Added `npm test` script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   , "repository": { "type": "git", "url": "git://github.com/visionmedia/should.js.git" }
   , "homepage": "https://github.com/visionmedia/should.js"
   , "contributors": [ "Aseem Kishore <aseem.kishore@gmail.com>" ]
+  , "scripts": { "test": "make test" }
   , "devDependencies": {
       "mocha": "*"
   }


### PR DESCRIPTION
`npm test` is a nice convention among Node.js packages for executing test harnesses. That way, developers don't have to specifically type each individual package's syntax (`make test`, `grunt test`, `vows`, etc.) and can get by with less yak shaving.
