### PR TITLE
Update should.js

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -709,6 +709,23 @@ Assertion.prototype = {
       , function(){ return 'expected no exception to be thrown, got "' + err.message + '"' });
 
     return this;
+  },
+  
+  /**
+   * Assert that this value approximates _value_ within _precision_ digits
+   * 
+   * @return {Assertion} for chaining
+   * @api public
+   */
+  approximate: function(value, precision) {
+    precision = precision || 6;
+    
+    this.assert(
+        Math.abs(this.obj - value) < Math.pow(10, -precision)
+      , function(){ return 'expected ' + this.inspect + ' to approximate ' + value + ' to ' + precision + ' digits' }
+      , function(){ return 'expected ' + this.inspect + ' to not approximate ' + value + ' to ' + precision + ' digits' });
+    
+    return this;
   }
 };
 

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -659,6 +658,12 @@ module.exports = {
     err(function(){
       (function(){ throw 'error'; }).should.throw(Error);
     }, "expected an exception to be thrown of type Error, but got String");
+  },
+  
+  'test approximate()': function(){
+    (0.8).should.approximate(0.80000001);
+    (0.8).should.approximate(0.80000001, 3);
+    (0.8).should.not.approximate(0.8001, 8);
   }
 
 };


### PR DESCRIPTION
Add `Object.should.approximate(value, [precision])` for checking if two floating-point numbers approximate each other.
