### PR TITLE
Fix behavior of instanceOf if valueOf defined

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -72,7 +72,10 @@ exports.not.exist = exports.not.exists = function(obj, msg){
 Object.defineProperty(Object.prototype, 'should', {
   set: function(){},
   get: function(){
-    return new Assertion(this.valueOf() == this ? this.valueOf() : this);
+    var textRepr  = toString.call(this);
+    var notObject = (textRepr != '[object Object]');
+    var notDate   = (textRepr != '[object Date]');
+    return new Assertion(notDate && notObject ? this.valueOf() : this);
   },
   configurable: true
 });

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -142,6 +142,10 @@ module.exports = {
     err(function(){
       (9).should.an.instanceOf(Foo, 'foo');
     }, "expected 9 to be an instance of Foo | foo");
+
+    function Foo2(){}
+    Foo2.prototype.valueOf = function (){ return 'foo'; };
+    new Foo2().should.be.an.instanceOf(Foo2);
   },
 
   'test within(start, finish)': function(){


### PR DESCRIPTION
- Fixes behavior of instanceOf reported in #107. If custom valueOf
  returned a primitive, Object.should type-coerced the object under test.
- Adds a test to verify correct behavior.
