### PR TITLE
eql should compare with ==

### DIFF
--- a/lib/eql.js
+++ b/lib/eql.js
@@ -28,7 +28,7 @@ function _deepEqual(actual, expected) {
   // 7.3. Other pairs that do not both pass typeof value == "object",
   // equivalence is determined by ==.
   } else if (typeof actual != 'object' && typeof expected != 'object') {
-    return actual === expected;
+    return actual == expected;
 
   // 7.4. For all other Object pairs, including Array objects, equivalence is
   // determined by having the same number of owned properties (as verified

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -261,7 +261,7 @@ module.exports = {
     'test'.should.eql('test');
     ({ foo: 'bar' }).should.eql({ foo: 'bar' });
     (1).should.eql(1);
-    '4'.should.not.eql(4);
+    '4'.should.eql(4);
     var memo = [];
     function memorize() {
         memo.push(arguments);


### PR DESCRIPTION
Discussed in #107. `eql` implies it provides non-strict equality checking, but in some cases
falls back to using `===` even though the accompanying comment indicates
it should do otherwise. Restore `==` comparison and fix affected test.
