### PR TITLE
Allow for optionally specifying arguments

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -662,6 +662,11 @@ Assertion.prototype = {
     return this;
   },
 
+  whenPassed: function() {
+    this.args = Array.prototype.slice.call(arguments);
+    return this;
+  },
+
   /**
    * Assert that this function will or will not
    * throw an exception.
@@ -677,7 +682,9 @@ Assertion.prototype = {
       , ok = true;
 
     try {
-      fn();
+      fn.apply(null, this.args);
+
+
       ok = false;
     } catch (e) {
       err = e;

--- a/lib/should.js
+++ b/lib/should.js
@@ -683,8 +683,6 @@ Assertion.prototype = {
 
     try {
       fn.apply(null, this.args);
-
-
       ok = false;
     } catch (e) {
       err = e;

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -610,6 +610,11 @@ module.exports = {
     }, "expected an exception to be thrown of type Error, but got String");
   },
 
+  'test whenPassed()': function(){
+    (function(n) { if (n < 0) throw new Error('fail')}).should.whenPassed(-1).throw();
+    (function(n) { if (n < 0) throw new Error('fail')}).should.whenPassed(1).not.throw();
+  },
+
   'test throwError()': function(){
     (function(){}).should.not.throwError();
     (function(){ throw new Error('fail') }).should.throwError();


### PR DESCRIPTION
Makes it easier to test argument-dependent exceptions. Related to issue #121.
