### PR TITLE
Closes #53 - 'a' and 'an' is now similar, 'have.type' replaces 'be.a'.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,10 +54,12 @@ which is essentially equivalent to below, however the property may not exist:
 ```javascript
 user.pets.should.have.lengthOf(4)
 ```
-our dummy getters such as _and_ also help express chaining:
+our dummy getters such as _a_, _an_, _be_ and _have_ make tests more readable while the getters _and_ and _with_ helps express chaining:
 ```javascript
-user.should.be.a('object').and.have.property('name', 'tj')
+user.should.be.an.instanceOf(Object).and.have.property('name', 'tj')
+user.should.have.property('pets').with.a.lengthOf(4)
 ```
+
 ## exist (static)
 
 The returned object from `require('should')` is the same object as `require('assert')`. So you can use `should` just like `assert`:
@@ -164,12 +166,12 @@ Assert floating point number:
 ```javascript
 (99.99).should.be.approximately(100, 0.1);
 ```
-## a
+## type
 
 Assert __typeof__:
 ```javascript
-user.should.be.a('object')
-'test'.should.be.a('string')
+user.should.have.type('object')
+'test'.should.have.type('string')
 ```
 ## instanceof and instanceOf
 

--- a/lib/should.js
+++ b/lib/should.js
@@ -154,6 +154,16 @@ Assertion.prototype = {
    * @api public
    */
 
+  get a() {
+    return this;
+  },
+
+  /**
+   * Dummy getter.
+   *
+   * @api public
+   */
+
   get and() {
     return this;
   },
@@ -359,11 +369,11 @@ Assertion.prototype = {
    * @api public
    */
 
-  a: function(type, desc){
+  type: function(type, desc){
     this.assert(
         type == typeof this.obj
-      , function(){ return 'expected ' + this.inspect + ' to be a ' + type + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' not to be a ' + type  + (desc ? " | " + desc : "") })
+      , function(){ return 'expected ' + this.inspect + ' to have type ' + type + (desc ? " | " + desc : "") }
+      , function(){ return 'expected ' + this.inspect + ' not to have type ' + type  + (desc ? " | " + desc : "") })
     return this;
   },
 

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -81,25 +81,25 @@ module.exports = {
   },
 
   'test typeof': function(){
-    'test'.should.be.a('string');
+    'test'.should.have.type('string');
 
     err(function(){
-      'test'.should.not.be.a('string');
-    }, "expected 'test' not to be a string");
+      'test'.should.not.have.type('string');
+    }, "expected 'test' not to have type string");
 
     err(function(){
-      'test'.should.not.be.a('string', 'foo');
-    }, "expected 'test' not to be a string | foo");
+      'test'.should.not.have.type('string', 'foo');
+    }, "expected 'test' not to have type string | foo");
 
-    (5).should.be.a('number');
-
-    err(function(){
-      (5).should.not.be.a('number');
-    }, "expected 5 not to be a number");
+    (5).should.have.type('number');
 
     err(function(){
-      (5).should.not.be.a('number', 'foo');
-    }, "expected 5 not to be a number | foo");
+      (5).should.not.have.type('number');
+    }, "expected 5 not to have type number");
+
+    err(function(){
+      (5).should.not.have.type('number', 'foo');
+    }, "expected 5 not to have type number | foo");
   },
 
   'test instanceof': function(){
@@ -616,7 +616,7 @@ module.exports = {
       user.should.have.property('pets').with.lengthOf(5);
     }, "expected [ 'tobi', 'loki', 'jane', 'bandit' ] to have a length of 5 but got 4");
 
-    user.should.be.a('object').and.have.property('name', 'tj');
+    user.should.be.instanceOf(Object).and.have.property('name', 'tj');
   },
 
   'test throw()': function(){

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -610,13 +610,13 @@ module.exports = {
 
   'test chaining': function(){
     var user = { name: 'tj', pets: ['tobi', 'loki', 'jane', 'bandit'] };
-    user.should.have.property('pets').with.lengthOf(4);
+    user.should.have.property('pets').with.a.lengthOf(4);
 
     err(function(){
       user.should.have.property('pets').with.lengthOf(5);
     }, "expected [ 'tobi', 'loki', 'jane', 'bandit' ] to have a length of 5 but got 4");
 
-    user.should.be.instanceOf(Object).and.have.property('name', 'tj');
+    user.should.be.an.instanceOf(Object).and.have.property('name', 'tj');
   },
 
   'test throw()': function(){


### PR DESCRIPTION
This fixes #53. However, after making the change it seems like there is no need for the 'a'. The 'an' method is useful for foo.should.be.an.instanceOf(Object). But when can 'a' be used with the current crop of matchers?

So just see this pull request as a part of the discussion. I'm not as sure anymore whether it is a good idea at all.
