### PR TITLE
Custom messages on the error object

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -296,8 +296,8 @@ Assertion.prototype = {
   eql: function(val, description){
     this.assert(
         eql(val, this.obj)
-      , function(){ return 'expected ' + this.inspect + ' to equal ' + i(val) }
-      , function(){ return 'expected ' + this.inspect + ' to not equal ' + i(val) }
+      , function(){ return 'expected ' + this.inspect + ' to equal ' + i(val) + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' to not equal ' + i(val) + (description ? " | " + description : "") }
       , val
       , true
       , description);
@@ -315,8 +315,8 @@ Assertion.prototype = {
   equal: function(val, description){
     this.assert(
         val === this.obj
-      , function(){ return 'expected ' + this.inspect + ' to equal ' + i(val) }
-      , function(){ return 'expected ' + this.inspect + ' to not equal ' + i(val) }
+      , function(){ return 'expected ' + this.inspect + ' to equal ' + i(val) + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' to not equal ' + i(val) + (description ? " | " + description : "") }
       , val
       , void 0
       , description);
@@ -336,8 +336,8 @@ Assertion.prototype = {
     var range = start + '..' + finish;
     this.assert(
         this.obj >= start && this.obj <= finish
-      , function(){ return 'expected ' + this.inspect + ' to be within ' + range }
-      , function(){ return 'expected ' + this.inspect + ' to not be within ' + range }
+      , function(){ return 'expected ' + this.inspect + ' to be within ' + range + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' to not be within ' + range + (description ? " | " + description : "") }
       , void 0
       , void 0
       , description);
@@ -356,8 +356,8 @@ Assertion.prototype = {
   approximately: function(value, delta, description) {
     this.assert(
       Math.abs(this.obj - value) <= delta
-      , function(){ return 'expected ' + this.inspect + ' to be approximately ' + value + " +- " + delta }
-      , function(){ return 'expected ' + this.inspect + ' to not be approximately ' + value + " +- " + delta }
+      , function(){ return 'expected ' + this.inspect + ' to be approximately ' + value + " +- " + delta + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' to not be approximately ' + value + " +- " + delta + (description ? " | " + description : "") }
       , void 0
       , void 0
       , description);
@@ -375,8 +375,8 @@ Assertion.prototype = {
   a: function(type, description){
     this.assert(
         type == typeof this.obj
-      , function(){ return 'expected ' + this.inspect + ' to be a ' + type }
-      , function(){ return 'expected ' + this.inspect + ' not to be a ' + type }
+      , function(){ return 'expected ' + this.inspect + ' to be a ' + type + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' not to be a ' + type + (description ? " | " + description : "") }
       , void 0
       , void 0
       , description);
@@ -395,8 +395,8 @@ Assertion.prototype = {
     var name = constructor.name;
     this.assert(
         this.obj instanceof constructor
-      , function(){ return 'expected ' + this.inspect + ' to be an instance of ' + name }
-      , function(){ return 'expected ' + this.inspect + ' not to be an instance of ' + name }
+      , function(){ return 'expected ' + this.inspect + ' to be an instance of ' + name + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' not to be an instance of ' + name + (description ? " | " + description : "") }
       , void 0
       , void 0
       , description);
@@ -414,8 +414,8 @@ Assertion.prototype = {
   above: function(n, description){
     this.assert(
         this.obj > n
-      , function(){ return 'expected ' + this.inspect + ' to be above ' + n }
-      , function(){ return 'expected ' + this.inspect + ' to be below ' + n }
+      , function(){ return 'expected ' + this.inspect + ' to be above ' + n + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' to be below ' + n + (description ? " | " + description : "") }
       , void 0
       , void 0
       , description);
@@ -433,8 +433,8 @@ Assertion.prototype = {
   below: function(n, description){
     this.assert(
         this.obj < n
-      , function(){ return 'expected ' + this.inspect + ' to be below ' + n }
-      , function(){ return 'expected ' + this.inspect + ' to be above ' + n }
+      , function(){ return 'expected ' + this.inspect + ' to be below ' + n + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' to be above ' + n + (description ? " | " + description : "") }
       , void 0
       , void 0
       , description);
@@ -452,8 +452,8 @@ Assertion.prototype = {
   match: function(regexp, description){
     this.assert(
         regexp.exec(this.obj)
-      , function(){ return 'expected ' + this.inspect + ' to match ' + regexp }
-      , function(){ return 'expected ' + this.inspect + ' not to match ' + regexp }
+      , function(){ return 'expected ' + this.inspect + ' to match ' + regexp + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' not to match ' + regexp + (description ? " | " + description : "") }
       , void 0
       , void 0
       , description);
@@ -473,8 +473,8 @@ Assertion.prototype = {
     var len = this.obj.length;
     this.assert(
         n == len
-      , function(){ return 'expected ' + this.inspect + ' to have a length of ' + n + ' but got ' + len }
-      , function(){ return 'expected ' + this.inspect + ' to not have a length of ' + len }
+      , function(){ return 'expected ' + this.inspect + ' to have a length of ' + n + ' but got ' + len + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' to not have a length of ' + len + (description ? " | " + description : "") }
       , void 0
       , void 0
       , description);
@@ -498,8 +498,8 @@ Assertion.prototype = {
     } else {
       this.assert(
           undefined !== this.obj[name]
-        , function(){ return 'expected ' + this.inspect + ' to have a property ' + i(name) }
-        , function(){ return 'expected ' + this.inspect + ' to not have a property ' + i(name) }
+        , function(){ return 'expected ' + this.inspect + ' to have a property ' + i(name) + (description ? " | " + description : "") }
+        , function(){ return 'expected ' + this.inspect + ' to not have a property ' + i(name) + (description ? " | " + description : "") }
         , void 0
         , void 0
         , description);
@@ -509,8 +509,8 @@ Assertion.prototype = {
       this.assert(
           val === this.obj[name]
         , function(){ return 'expected ' + this.inspect + ' to have a property ' + i(name)
-          + ' of ' + i(val) + ', but got ' + i(this.obj[name]) }
-        , function(){ return 'expected ' + this.inspect + ' to not have a property ' + i(name) + ' of ' + i(val) }
+          + ' of ' + i(val) + ', but got ' + i(this.obj[name]) + (description ? " | " + description : "") }
+        , function(){ return 'expected ' + this.inspect + ' to not have a property ' + i(name) + ' of ' + i(val) + (description ? " | " + description : "") }
         , void 0
         , void 0
         , description);
@@ -531,8 +531,8 @@ Assertion.prototype = {
   ownProperty: function(name, description){
     this.assert(
         this.obj.hasOwnProperty(name)
-      , function(){ return 'expected ' + this.inspect + ' to have own property ' + i(name) }
-      , function(){ return 'expected ' + this.inspect + ' to not have own property ' + i(name) }
+      , function(){ return 'expected ' + this.inspect + ' to have own property ' + i(name) + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' to not have own property ' + i(name) + (description ? " | " + description : "") }
       , void 0
       , void 0
       , description);
@@ -549,8 +549,8 @@ Assertion.prototype = {
 
   startWith: function(str, description) {
     this.assert(0 === this.obj.indexOf(str)
-    , function() { return 'expected ' + this.inspect + ' to start with ' + i(str) }
-    , function() { return 'expected ' + this.inspect + ' to not start with ' + i(str) }
+    , function() { return 'expected ' + this.inspect + ' to start with ' + i(str) + (description ? " | " + description : "") }
+    , function() { return 'expected ' + this.inspect + ' to not start with ' + i(str) + (description ? " | " + description : "") }
     , void 0
     , void 0
     , description);
@@ -566,8 +566,8 @@ Assertion.prototype = {
 
   endWith: function(str, description) {
     this.assert(-1 !== this.obj.indexOf(str, this.obj.length - str.length)
-    , function() { return 'expected ' + this.inspect + ' to end with ' + i(str) }
-    , function() { return 'expected ' + this.inspect + ' to not end with ' + i(str) }
+    , function() { return 'expected ' + this.inspect + ' to end with ' + i(str) + (description ? " | " + description : "") }
+    , function() { return 'expected ' + this.inspect + ' to not end with ' + i(str) + (description ? " | " + description : "") }
     , void 0
     , void 0
     , description);
@@ -588,16 +588,16 @@ Assertion.prototype = {
       for (var key in obj) cmp[key] = this.obj[key];
       this.assert(
           eql(cmp, obj)
-        , function(){ return 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) }
-        , function(){ return 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) }
+        , function(){ return 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) + (description ? " | " + description : "") }
+        , function(){ return 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) + (description ? " | " + description : "") }
         , void 0
         , void 0
         , description);
     } else {
       this.assert(
           ~this.obj.indexOf(obj)
-        , function(){ return 'expected ' + this.inspect + ' to include ' + i(obj) }
-        , function(){ return 'expected ' + this.inspect + ' to not include ' + i(obj) }
+        , function(){ return 'expected ' + this.inspect + ' to include ' + i(obj) + (description ? " | " + description : "") }
+        , function(){ return 'expected ' + this.inspect + ' to not include ' + i(obj) + (description ? " | " + description : "") }
         , void 0
         , void 0
         , description);
@@ -616,8 +616,8 @@ Assertion.prototype = {
   includeEql: function(obj, description){
     this.assert(
       this.obj.some(function(item) { return eql(obj, item); })
-      , function(){ return 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) }
-      , function(){ return 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) }
+      , function(){ return 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) + (description ? " | " + description : "") }
+      , function(){ return 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) + (description ? " | " + description : "") }
       , void 0
       , void 0
       , description);

--- a/lib/should.js
+++ b/lib/should.js
@@ -40,7 +40,7 @@ util.merge(should, assert);
 /**
  * Assert _obj_ exists, with optional message.
  *
- * @param {Mixed} obj
+ * @param {*} obj
  * @param {String} [msg]
  * @api public
  */
@@ -56,7 +56,7 @@ should.exist = should.exists = function(obj, msg) {
 /**
  * Asserts _obj_ does not exist, with optional message.
  *
- * @param {Mixed} obj
+ * @param {*} obj
  * @param {String} [msg]
  * @api public
  */
@@ -94,7 +94,7 @@ Object.defineProperty(Object.prototype, 'should', {
 /**
  * Initialize a new `Assertion` with the given _obj_.
  *
- * @param {Mixed} obj
+ * @param {*} obj
  * @api private
  */
 
@@ -112,15 +112,18 @@ Assertion.prototype = {
    * Assert _expr_ with the given _msg_ and _negatedMsg_.
    *
    * @param {Boolean} expr
-   * @param {String} msg
-   * @param {String} negatedMsg
-   * @param {Object} expected
+   * @param {function} msg
+   * @param {function} negatedMsg
+   * @param {Object} [expected]
+   * @param {Boolean} [showDiff]
+   * @param {String} [description]
    * @api private
    */
 
-  assert: function(expr, msg, negatedMsg, expected, showDiff){
-    var msg = this.negate ? negatedMsg : msg
-      , ok = this.negate ? !expr : expr
+  assert: function(expr, msg, negatedMsg, expected, showDiff, description){
+    msg = this.negate ? negatedMsg : msg
+
+    var ok = this.negate ? !expr : expr
       , obj = this.obj;
 
     if (ok) return;
@@ -134,6 +137,7 @@ Assertion.prototype = {
     });
 
     err.showDiff = showDiff;
+    err.description = description
 
     throw err;
   },
@@ -284,35 +288,38 @@ Assertion.prototype = {
   /**
    * Assert equal.
    *
-   * @param {Mixed} val
+   * @param {*} val
    * @param {String} description
    * @api public
    */
 
-  eql: function(val, desc){
+  eql: function(val, description){
     this.assert(
         eql(val, this.obj)
-      , function(){ return 'expected ' + this.inspect + ' to equal ' + i(val) + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' to not equal ' + i(val) + (desc ? " | " + desc : "") }
+      , function(){ return 'expected ' + this.inspect + ' to equal ' + i(val) }
+      , function(){ return 'expected ' + this.inspect + ' to not equal ' + i(val) }
       , val
-      , true);
+      , true
+      , description);
     return this;
   },
 
   /**
    * Assert strict equal.
    *
-   * @param {Mixed} val
+   * @param {*} val
    * @param {String} description
    * @api public
    */
 
-  equal: function(val, desc){
+  equal: function(val, description){
     this.assert(
         val === this.obj
-      , function(){ return 'expected ' + this.inspect + ' to equal ' + i(val) + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' to not equal ' + i(val) + (desc ? " | " + desc : "") }
-      , val);
+      , function(){ return 'expected ' + this.inspect + ' to equal ' + i(val) }
+      , function(){ return 'expected ' + this.inspect + ' to not equal ' + i(val) }
+      , val
+      , void 0
+      , description);
     return this;
   },
 
@@ -325,12 +332,15 @@ Assertion.prototype = {
    * @api public
    */
 
-  within: function(start, finish, desc){
+  within: function(start, finish, description){
     var range = start + '..' + finish;
     this.assert(
         this.obj >= start && this.obj <= finish
-      , function(){ return 'expected ' + this.inspect + ' to be within ' + range + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' to not be within ' + range + (desc ? " | " + desc : "") });
+      , function(){ return 'expected ' + this.inspect + ' to be within ' + range }
+      , function(){ return 'expected ' + this.inspect + ' to not be within ' + range }
+      , void 0
+      , void 0
+      , description);
     return this;
   },
 
@@ -346,24 +356,30 @@ Assertion.prototype = {
   approximately: function(value, delta, description) {
     this.assert(
       Math.abs(this.obj - value) <= delta
-      , function(){ return 'expected ' + this.inspect + ' to be approximately ' + value + " +- " + delta + (description ? " | " + description : "") }
-      , function(){ return 'expected ' + this.inspect + ' to not be approximately ' + value + " +- " + delta + (description ? " | " + description : "") });
+      , function(){ return 'expected ' + this.inspect + ' to be approximately ' + value + " +- " + delta }
+      , function(){ return 'expected ' + this.inspect + ' to not be approximately ' + value + " +- " + delta }
+      , void 0
+      , void 0
+      , description);
     return this;
   },
 
   /**
    * Assert typeof.
    *
-   * @param {Mixed} type
+   * @param {*} type
    * @param {String} description
    * @api public
    */
 
-  a: function(type, desc){
+  a: function(type, description){
     this.assert(
         type == typeof this.obj
-      , function(){ return 'expected ' + this.inspect + ' to be a ' + type + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' not to be a ' + type  + (desc ? " | " + desc : "") })
+      , function(){ return 'expected ' + this.inspect + ' to be a ' + type }
+      , function(){ return 'expected ' + this.inspect + ' not to be a ' + type }
+      , void 0
+      , void 0
+      , description);
     return this;
   },
 
@@ -375,12 +391,15 @@ Assertion.prototype = {
    * @api public
    */
 
-  instanceof: function(constructor, desc){
+  instanceof: function(constructor, description){
     var name = constructor.name;
     this.assert(
         this.obj instanceof constructor
-      , function(){ return 'expected ' + this.inspect + ' to be an instance of ' + name + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' not to be an instance of ' + name + (desc ? " | " + desc : "") });
+      , function(){ return 'expected ' + this.inspect + ' to be an instance of ' + name }
+      , function(){ return 'expected ' + this.inspect + ' not to be an instance of ' + name }
+      , void 0
+      , void 0
+      , description);
     return this;
   },
 
@@ -392,11 +411,14 @@ Assertion.prototype = {
    * @api public
    */
 
-  above: function(n, desc){
+  above: function(n, description){
     this.assert(
         this.obj > n
-      , function(){ return 'expected ' + this.inspect + ' to be above ' + n + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' to be below ' + n + (desc ? " | " + desc : "") });
+      , function(){ return 'expected ' + this.inspect + ' to be above ' + n }
+      , function(){ return 'expected ' + this.inspect + ' to be below ' + n }
+      , void 0
+      , void 0
+      , description);
     return this;
   },
 
@@ -408,11 +430,14 @@ Assertion.prototype = {
    * @api public
    */
 
-  below: function(n, desc){
+  below: function(n, description){
     this.assert(
         this.obj < n
-      , function(){ return 'expected ' + this.inspect + ' to be below ' + n + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' to be above ' + n + (desc ? " | " + desc : "") });
+      , function(){ return 'expected ' + this.inspect + ' to be below ' + n }
+      , function(){ return 'expected ' + this.inspect + ' to be above ' + n }
+      , void 0
+      , void 0
+      , description);
     return this;
   },
 
@@ -424,11 +449,14 @@ Assertion.prototype = {
    * @api public
    */
 
-  match: function(regexp, desc){
+  match: function(regexp, description){
     this.assert(
         regexp.exec(this.obj)
-      , function(){ return 'expected ' + this.inspect + ' to match ' + regexp + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' not to match ' + regexp + (desc ? " | " + desc : "") });
+      , function(){ return 'expected ' + this.inspect + ' to match ' + regexp }
+      , function(){ return 'expected ' + this.inspect + ' not to match ' + regexp }
+      , void 0
+      , void 0
+      , description);
     return this;
   },
 
@@ -440,13 +468,16 @@ Assertion.prototype = {
    * @api public
    */
 
-  length: function(n, desc){
+  length: function(n, description){
     this.obj.should.have.property('length');
     var len = this.obj.length;
     this.assert(
         n == len
-      , function(){ return 'expected ' + this.inspect + ' to have a length of ' + n + ' but got ' + len + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' to not have a length of ' + len + (desc ? " | " + desc : "") });
+      , function(){ return 'expected ' + this.inspect + ' to have a length of ' + n + ' but got ' + len }
+      , function(){ return 'expected ' + this.inspect + ' to not have a length of ' + len }
+      , void 0
+      , void 0
+      , description);
     return this;
   },
 
@@ -454,29 +485,35 @@ Assertion.prototype = {
    * Assert property _name_ exists, with optional _val_.
    *
    * @param {String} name
-   * @param {Mixed} [val]
+   * @param {*} [val]
    * @param {String} description
    * @api public
    */
 
-  property: function(name, val, desc){
+  property: function(name, val, description){
     if (this.negate && undefined !== val) {
       if (undefined === this.obj[name]) {
-        throw new Error(this.inspect + ' has no property ' + i(name) + (desc ? " | " + desc : ""));
+        throw new Error(this.inspect + ' has no property ' + i(name) + (description ? " | " + description : ""));
       }
     } else {
       this.assert(
           undefined !== this.obj[name]
-        , function(){ return 'expected ' + this.inspect + ' to have a property ' + i(name) + (desc ? " | " + desc : "") }
-        , function(){ return 'expected ' + this.inspect + ' to not have a property ' + i(name) + (desc ? " | " + desc : "") });
+        , function(){ return 'expected ' + this.inspect + ' to have a property ' + i(name) }
+        , function(){ return 'expected ' + this.inspect + ' to not have a property ' + i(name) }
+        , void 0
+        , void 0
+        , description);
     }
 
     if (undefined !== val) {
       this.assert(
           val === this.obj[name]
         , function(){ return 'expected ' + this.inspect + ' to have a property ' + i(name)
-          + ' of ' + i(val) + ', but got ' + i(this.obj[name]) + (desc ? " | " + desc : "") }
-        , function(){ return 'expected ' + this.inspect + ' to not have a property ' + i(name) + ' of ' + i(val) + (desc ? " | " + desc : "") });
+          + ' of ' + i(val) + ', but got ' + i(this.obj[name]) }
+        , function(){ return 'expected ' + this.inspect + ' to not have a property ' + i(name) + ' of ' + i(val) }
+        , void 0
+        , void 0
+        , description);
     }
 
     this.obj = this.obj[name];
@@ -491,11 +528,14 @@ Assertion.prototype = {
    * @api public
    */
 
-  ownProperty: function(name, desc){
+  ownProperty: function(name, description){
     this.assert(
         this.obj.hasOwnProperty(name)
-      , function(){ return 'expected ' + this.inspect + ' to have own property ' + i(name) + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' to not have own property ' + i(name) + (desc ? " | " + desc : "") });
+      , function(){ return 'expected ' + this.inspect + ' to have own property ' + i(name) }
+      , function(){ return 'expected ' + this.inspect + ' to not have own property ' + i(name) }
+      , void 0
+      , void 0
+      , description);
     this.obj = this.obj[name];
     return this;
   },
@@ -503,52 +543,64 @@ Assertion.prototype = {
   /**
    * Assert that string starts with `str`.
    * @param {String} str
-   * @param {String} desc
+   * @param {String} description
    * @api public
    */
 
-  startWith: function(str, desc) {
+  startWith: function(str, description) {
     this.assert(0 === this.obj.indexOf(str)
-    , function() { return 'expected ' + this.inspect + ' to start with ' + i(str) + (desc ? " | " + desc : "") }
-    , function() { return 'expected ' + this.inspect + ' to not start with ' + i(str) + (desc ? " | " + desc : "") });
+    , function() { return 'expected ' + this.inspect + ' to start with ' + i(str) }
+    , function() { return 'expected ' + this.inspect + ' to not start with ' + i(str) }
+    , void 0
+    , void 0
+    , description);
     return this;
   },
 
   /**
    * Assert that string ends with `str`.
    * @param {String} str
-   * @param {String} desc
+   * @param {String} description
    * @api public
    */
 
-  endWith: function(str, desc) {
+  endWith: function(str, description) {
     this.assert(-1 !== this.obj.indexOf(str, this.obj.length - str.length)
-    , function() { return 'expected ' + this.inspect + ' to end with ' + i(str) + (desc ? " | " + desc : "") }
-    , function() { return 'expected ' + this.inspect + ' to not end with ' + i(str) + (desc ? " | " + desc : "") });
+    , function() { return 'expected ' + this.inspect + ' to end with ' + i(str) }
+    , function() { return 'expected ' + this.inspect + ' to not end with ' + i(str) }
+    , void 0
+    , void 0
+    , description);
     return this;
   },
 
   /**
    * Assert that `obj` is present via `.indexOf()`.
    *
-   * @param {Mixed} obj
+   * @param {*} obj
    * @param {String} description
    * @api public
    */
 
-  include: function(obj, desc){
+  include: function(obj, description){
     if (obj.constructor == Object){
       var cmp = {};
       for (var key in obj) cmp[key] = this.obj[key];
       this.assert(
           eql(cmp, obj)
-        , function(){ return 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) + (desc ? " | " + desc : "") }
-        , function(){ return 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) + (desc ? " | " + desc : "") });
+        , function(){ return 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) }
+        , function(){ return 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) }
+        , void 0
+        , void 0
+        , description);
     } else {
       this.assert(
           ~this.obj.indexOf(obj)
-        , function(){ return 'expected ' + this.inspect + ' to include ' + i(obj) + (desc ? " | " + desc : "") }
-        , function(){ return 'expected ' + this.inspect + ' to not include ' + i(obj) + (desc ? " | " + desc : "") });
+        , function(){ return 'expected ' + this.inspect + ' to include ' + i(obj) }
+        , function(){ return 'expected ' + this.inspect + ' to not include ' + i(obj) }
+        , void 0
+        , void 0
+        , description);
     }
     return this;
   },
@@ -561,18 +613,21 @@ Assertion.prototype = {
    * @api public
    */
 
-  includeEql: function(obj, desc){
+  includeEql: function(obj, description){
     this.assert(
       this.obj.some(function(item) { return eql(obj, item); })
-      , function(){ return 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) + (desc ? " | " + desc : "") }
-      , function(){ return 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) + (desc ? " | " + desc : "") });
+      , function(){ return 'expected ' + this.inspect + ' to include an object equal to ' + i(obj) }
+      , function(){ return 'expected ' + this.inspect + ' to not include an object equal to ' + i(obj) }
+      , void 0
+      , void 0
+      , description);
     return this;
   },
 
   /**
    * Assert that the array contains _obj_.
    *
-   * @param {Mixed} obj
+   * @param {*} obj
    * @api public
    */
 


### PR DESCRIPTION
The main goal of this pull request is to add the custom message to the error object so that it can be referenced without doing string manipulation on the error message itself (splitting at the pipe).

I also did some doc fixing and whatnot
