### PR TITLE
Remove the var assigment for should in the docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ It extends the Object prototype with a single non-enumerable getter that allows 
 
 ## Example
 ```javascript
-var should = require('should');
+require('should');
 
 var user = {
     name: 'tj'
@@ -403,7 +403,7 @@ The methods that support this optional description are: `eql`, `equal`, `within`
 For example you can use should with the [Mocha test framework](http://visionmedia.github.io/mocha/) by simply including it:
 
 ```javascript
-var should = require('should');
+require('should');
 var mylib = require('mylib');
 
 


### PR DESCRIPTION
The variable has 2 value and it have no use (as variable), it also make JSHint warn you about an unused variable, just using require('should'); will still do the magic and JSHint is going to be happy about that
