### PR TITLE
Let instanceof() accept wrapped primitives

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -466,7 +466,7 @@ Assertion.prototype = {
   instanceof: function(constructor, description){
     var name = constructor.name;
     this.assert(
-        this.obj instanceof constructor
+        Object(this.obj) instanceof constructor
       , function(){ return 'expected ' + this.inspect + ' to be an instance of ' + name + (description ? " | " + description : "") }
       , function(){ return 'expected ' + this.inspect + ' not to be an instance of ' + name + (description ? " | " + description : "") }
       , void 0

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -173,6 +173,10 @@ module.exports = {
     var getSomething = function() {return "something"};
     getSomething.should.be.an.instanceof(Function);
 
+    var number = Object(5);
+    (number instanceof Number).should.be.true;
+    number.should.be.an.instanceof(Number);
+
     err(function(){
       (3).should.an.instanceof(Foo);
     }, "expected 3 to be an instance of Foo");


### PR DESCRIPTION
I want to fix #156 by having instanceof() be optimistic in the case of primitive values, in order to compensate for should() invoking valueOf()

Note that type() is currently also optimistic:

```
var five = Object(5);
five.should.have.type('number'); // works
(typeof five).should.equal('number');  // throws
```
