### PR TITLE
add support for specifying property values w/ have.properties

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -667,17 +667,24 @@ Assertion.prototype = {
     this.obj = this.obj[name];
     return this;
   },
+
   /**
-   * Asset have given properties
-   * @param {Array|String ...} names
+   * Assert have given properties
+   *
+   * @param {Object|Array|String ...} properties
    * @api public
    */
-  properties: function(names) {
+
+  properties: function(properties) {
     var str
       , ok = true;
 
-    names = names instanceof Array
-      ? names
+    if (Object.prototype.toString.call(properties) === '[object Object]') {
+      return this.propertiesWithValues(properties);
+    }
+
+    var names = properties instanceof Array
+      ? properties
       : Array.prototype.slice.call(arguments);
 
     var len = names.length;
@@ -708,6 +715,27 @@ Assertion.prototype = {
       , function(){ return 'expected ' + this.inspect + ' to ' + str }
       , function(){ return 'expected ' + this.inspect + ' to not ' + str });
 
+    return this;
+  },
+
+  /**
+   * Assert have given properties with values.
+   *
+   * @param {Object} properties
+   */
+
+  propertiesWithValues: function(properties) {
+    var check = function(assertion) {
+      return assertion.negate
+        ? assertion.obj.should.not
+        : assertion.obj.should;
+    };
+
+    for (var name in properties) {
+      if (properties.hasOwnProperty(name)) {
+        check(this).have.property(name, properties[name]);
+      }
+    }
     return this;
   },
 

--- a/test/should.test.js
+++ b/test/should.test.js
@@ -609,6 +609,23 @@ module.exports = {
     }, "expected 'asd' to have a property 'foo'");
   },
 
+  'test properties({ name1: val1, name2: val2, ... })': function(){
+    'test'.should.have.properties({ length: 4 });
+    'test'.should.not.have.properties({ length: 5 });
+
+    err(function(){
+      'test'.should.have.properties({ length: 5 });
+    }, "expected 'test' to have a property 'length' of 5, but got 4");
+
+    var object = { foo: 1, bar: 2, baz: 3 };
+    object.should.have.properties({ foo: 1, bar: 2 });
+    object.should.not.have.properties({ foo: 2 });
+
+    err(function() {
+      object.should.have.properties({ foo: 1, bar: 3 });
+    }, "expected { foo: 1, bar: 2, baz: 3 } to have a property 'bar' of 3, but got 2");
+  },
+
   'test ownProperty(name)': function(){
     'test'.should.have.ownProperty('length');
     'test'.should.haveOwnProperty('length');


### PR DESCRIPTION
I'd like to be able to make assertions about just _some_ of an object's properties in a more concise way.

For example:

``` javascript
var object = {
  foo: 1,
  bar: 2,
  baz: 3
};

// Maybe I don't care about bar for this particular test
object.should.have.properties({
  foo: 1,
  bar: 2
});
```

This change provides that functionality.
