### PR TITLE
Fixes HTMLElement check error in DOM-less environments

### DIFF
--- a/lib/ext/browser/jquery.js
+++ b/lib/ext/browser/jquery.js
@@ -16,7 +16,7 @@ module.exports = function(should, Assertion) {
   var $ = this.jQuery || this.$;
 
   /* Otherwise, node's util.inspect loops hangs */
-  if (HTMLElement && !HTMLElement.prototype.inspect) {
+  if (typeof HTMLElement !== "undefined" && HTMLElement && !HTMLElement.prototype.inspect) {
     HTMLElement.prototype.inspect = function () {
       return this.outerHTML;
     };

--- a/should.js
+++ b/should.js
@@ -225,7 +225,7 @@ module.exports = function(should, Assertion) {
   var $ = this.jQuery || this.$;
 
   /* Otherwise, node's util.inspect loops hangs */
-  if (HTMLElement && !HTMLElement.prototype.inspect) {
+  if (typeof HTMLElement !== "undefined" && HTMLElement && !HTMLElement.prototype.inspect) {
     HTMLElement.prototype.inspect = function () {
       return this.outerHTML;
     };


### PR DESCRIPTION
When the check for `HTMLElement` was relaxed ([33331c92834106846196a1bf1c59ee032990ab81](https://github.com/visionmedia/should.js/commit/33331c92834106846196a1bf1c59ee032990ab81)), it inadvertently made the should.js browser-compatible version unusable in environments without a DOM. The prior `typeof` check made it safe. I know, it sounds like a worthless note, but [Appcelerator's Titanium](http://www.appcelerator.com/titanium/) was able to make full use of should.js before this commit. Now without a patch of some sort it cannot, ending in undefined exceptions.

I understand that the purpose of the single-file should.js is to support the browser. I humbly request, though, that unless the commit which relaxed the `HTMLElement` check was critical for some reason I am unaware of, please consider accepting this PR so that the Titanium community can continue using it in its unit testing suites again. 

All tests passing.
