### PR TITLE
Fixes jQuery checks in environments without DOM

### DIFF
--- a/lib/ext/browser/jquery.js
+++ b/lib/ext/browser/jquery.js
@@ -22,16 +22,18 @@ module.exports = function(should, Assertion) {
     };
   }
 
-  jQuery.fn.inspect = function () {
-    var elementList = this.toArray().map(function (e) {
-      return util.inspect(e);
-    }).join(", ");
-    if (this.selector) {
-      return "SELECTOR(" + this.selector + ") matching " + this.length + " elements" + (elementList.length ? ": " + elementList : "");
-    } else {
-      return elementList;
-    }
-  };
+  if (typeof jQuery !== "undefined" && jQuery && !jQuery.prototype.inspect) {
+    jQuery.fn.inspect = function () {
+      var elementList = this.toArray().map(function (e) {
+        return util.inspect(e);
+      }).join(", ");
+      if (this.selector) {
+        return "SELECTOR(" + this.selector + ") matching " + this.length + " elements" + (elementList.length ? ": " + elementList : "");
+      } else {
+        return elementList;
+      }
+    };
+  }
 
   function jQueryAttributeTestHelper(method, singular, plural, nameOrHash, value) {
     var keys = util.isObject(nameOrHash) ? Object.keys(nameOrHash) : [nameOrHash];

--- a/should.js
+++ b/should.js
@@ -231,16 +231,18 @@ module.exports = function(should, Assertion) {
     };
   }
 
-  jQuery.fn.inspect = function () {
-    var elementList = this.toArray().map(function (e) {
-      return util.inspect(e);
-    }).join(", ");
-    if (this.selector) {
-      return "SELECTOR(" + this.selector + ") matching " + this.length + " elements" + (elementList.length ? ": " + elementList : "");
-    } else {
-      return elementList;
-    }
-  };
+  if (typeof jQuery !== "undefined" && jQuery && !jQuery.prototype.inspect) {
+    jQuery.fn.inspect = function () {
+      var elementList = this.toArray().map(function (e) {
+        return util.inspect(e);
+      }).join(", ");
+      if (this.selector) {
+        return "SELECTOR(" + this.selector + ") matching " + this.length + " elements" + (elementList.length ? ": " + elementList : "");
+      } else {
+        return elementList;
+      }
+    };
+  }
 
   function jQueryAttributeTestHelper(method, singular, plural, nameOrHash, value) {
     var keys = util.isObject(nameOrHash) ? Object.keys(nameOrHash) : [nameOrHash];


### PR DESCRIPTION
This resolves the same exact issue as was addressed with `HTMLElement` in #173. The execution of "lib/ext/browser/jquery.js" assumes the presence of `jQuery` which won't be available in DOM-less environments like Appcelerator's Titanium. Checking for the existence of `jQuery` before attempting to update its prototype allows Titanium to make full use of should.js. 
