### PR TITLE
Returning original should call in error object

### DIFF
--- a/lib/ext/assert.js
+++ b/lib/ext/assert.js
@@ -33,7 +33,7 @@ module.exports = function(should) {
   should.exist = should.exists = function(obj, msg) {
     if(null == obj) {
       throw new AssertionError({
-        message: msg || ('expected ' + i(obj) + ' to exist'), stackStartFunction: should.exist
+        message: msg || ('expected ' + i(obj) + ' to exist' + util.getCall(true)), stackStartFunction: should.exist
       });
     }
   };
@@ -50,7 +50,7 @@ module.exports = function(should) {
   should.not.exist = should.not.exists = function(obj, msg) {
     if(null != obj) {
       throw new AssertionError({
-        message: msg || ('expected ' + i(obj) + ' to not exist'), stackStartFunction: should.not.exist
+        message: msg || ('expected ' + i(obj) + ' to not exist' + util.getCall(true)), stackStartFunction: should.not.exist
       });
     }
   };

--- a/lib/should.js
+++ b/lib/should.js
@@ -42,6 +42,7 @@ Assertion.add = function(name, f, isGetter) {
   prop[isGetter ? 'get' : 'value'] = function() {
     var context = new Assertion(this.obj);
     context.copy = context.copyIfMissing;
+    context.call = this.call || util.getCall();
 
     try {
       f.apply(context, arguments);
@@ -123,7 +124,7 @@ Assertion.prototype = {
 
     var msg = params.message, generatedMessage = false;
     if(!msg) {
-      msg = this.getMessage();
+      msg = this.getMessage() + (this.call ? ' | ' + this.call : '');
       generatedMessage = true;
     }
 
@@ -137,6 +138,7 @@ Assertion.prototype = {
     err.showDiff = params.showDiff;
     err.operator = params.operator;
     err.generatedMessage = generatedMessage;
+    err.call = this.call || '';
 
     throw err;
   },
@@ -148,10 +150,12 @@ Assertion.prototype = {
 
   copy: function(other) {
     this.params = other.params;
+    this.call = other.call;
   },
 
   copyIfMissing: function(other) {
     if(!this.params) this.params = other.params;
+    if(!this.call) this.call = other.call;
   },
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -38,6 +38,25 @@ exports.merge = function(a, b){
   return a;
 };
 
+/**
+ * Determine the original should call. Requires it to be wrapped in a
+ * self-invoking anonymous function.
+ *
+ * @param {boolean} [separated] - add separator ' | ' to original call
+ * @return {string}
+ * @api private
+ */
+
+exports.getCall = function(separated){
+  var caller = arguments.callee.caller.caller.toString();
+  var matches = caller.match(/^function *\(\)\s*{\s*return ([\s\S]*?\bshould\.[\s\S]*?);?\s*}$/);
+  if(matches) {
+    match = matches[1].replace(/\s\s+/g,' ');
+    return (separated ? ' | ' : '') + match;
+  }
+  return '';
+};
+
 function isNumber(arg) {
   return typeof arg === 'number' || arg instanceof Number;
 }


### PR DESCRIPTION
The way that we use should, we often run into issues with AssertionError messages not being specific enough to distinguish several should calls within the same test.

The changes suggested here add the original should call as a string to the AssertionError object `.message` and as a separate `.call` property. It requires the original call to be wrapped in an anonymous self-invoking function, which is easily done in CoffeeScript: `do -> a.should.eql(b)`.

The original call is then printed out with the error message and, with a small change in mocha's 'reporters/base.js' on [Line 356](https://github.com/visionmedia/mocha/blob/master/lib/reporters/base.js#L356): `+ (err.call ? err.call + '\n\n' : '')`, also by mocha's inline diff.

If you're interested in merging this feature in, I can add a couple of tests.
