### PR TITLE
Change NaN

### DIFF
--- a/lib/ext/number.js
+++ b/lib/ext/number.js
@@ -8,8 +8,7 @@ module.exports = function(should, Assertion) {
   Assertion.add('NaN', function() {
     this.params = { operator: 'to be NaN' };
 
-    this.is.a.Number
-      .and.assert(isNaN(this.obj));
+    this..assert(this.obj !== this.obj);
   }, true);
 
   Assertion.add('Infinity', function() {

--- a/lib/ext/number.js
+++ b/lib/ext/number.js
@@ -8,7 +8,7 @@ module.exports = function(should, Assertion) {
   Assertion.add('NaN', function() {
     this.params = { operator: 'to be NaN' };
 
-    this..assert(this.obj !== this.obj);
+    this.assert(this.obj !== this.obj);
   }, true);
 
   Assertion.add('Infinity', function() {


### PR DESCRIPTION
It's better to test for NaN using the popular idiom of not equality to itself, because isNaN returns true for all the values that can be coerced to NaN, for example for any string.
