### PR TITLE
use  .Null instead of .null for cross browser compatibility

### DIFF
--- a/lib/ext/property.js
+++ b/lib/ext/property.js
@@ -204,7 +204,7 @@ module.exports = function(should, Assertion) {
         var otherIdx = 0;
         obj.forEach(function(item) {
           try {
-            should(item).not.be.null.and.containDeep(other[otherIdx]);
+            should(item).not.be.Null.and.containDeep(other[otherIdx]);
             otherIdx++;
           } catch(e) {
             if(e instanceof should.AssertionError) {
@@ -223,7 +223,7 @@ module.exports = function(should, Assertion) {
     } else if(util.isObject(obj)) {// object contains object case
       if(util.isObject(other)) {
         util.forOwn(other, function(value, key) {
-          should(obj[key]).not.be.null.and.containDeep(value);
+          should(obj[key]).not.be.Null.and.containDeep(value);
         });
       } else {//one of the properties contain value
         this.assert(false);


### PR DESCRIPTION
Using .null will break on browsers that do not support js keywords as properties. When using .Null it works fine.
