### PR TITLE
Use should.format instead of i() in getMessage()

### DIFF
--- a/lib/should.js
+++ b/lib/should.js
@@ -84,7 +84,7 @@ Assertion.alias = function(from, to) {
 };
 
 should.AssertionError = AssertionError;
-var i = should.format = function i(value) {
+should.format = function (value) {
   if(util.isDate(value) && typeof value.inspect !== 'function') return value.toISOString(); //show millis in dates
   return inspect(value, { depth: null });
 };
@@ -145,8 +145,8 @@ Assertion.prototype = {
   },
 
   getMessage: function() {
-    return 'expected ' + ('obj' in this.params ? this.params.obj: i(this.obj)) + (this.negate ? ' not ': ' ') +
-        this.params.operator + ('expected' in this.params  ? ' ' + i(this.params.expected) : '');
+    return 'expected ' + ('obj' in this.params ? this.params.obj: should.format(this.obj)) + (this.negate ? ' not ': ' ') +
+       this.params.operator + ('expected' in this.params  ? ' ' + should.format(this.params.expected) : '');
   },
 
   copy: function(other) {


### PR DESCRIPTION
This allows should.format to be overridden.  Gives user of should.js ability to use custom formatters.

I have had issues with using Should.js with very large object.  Generating exceptions would take several seconds and resulting error message string would be over 2MB.
