### PR TITLE
aliased deepEqual to eql

### DIFF
--- a/lib/ext/eql.js
+++ b/lib/ext/eql.js
@@ -20,4 +20,5 @@ module.exports = function(should, Assertion) {
   });
 
   Assertion.alias('equal', 'exactly');
+  Assertion.alias('eql', 'deepEqual');
 };


### PR DESCRIPTION
Aliased `should.eql` to `should.deepEqual`, because it doesn't make sense not to.

``` javascript
([1234]).should.deepEqual([1234]); // now works!
```

<sup>Hint: we already had `should.deepEqual`; it just didn't exist on `should` object prototypes :+1:</sup>
